### PR TITLE
[Feat] LazyColumn에 Sample API 데이터 뿌리기 구현

### DIFF
--- a/core/data/src/main/java/team/ppac/data/mapper/SampleMapper.kt
+++ b/core/data/src/main/java/team/ppac/data/mapper/SampleMapper.kt
@@ -5,6 +5,6 @@ import team.ppac.remote.model.sample.SampleResponse
 
 internal fun List<SampleResponse>.toDomain(): List<SampleImageModel> {
     return this.map { sampleResponse ->
-        SampleImageModel(sampleResponse.url, sampleResponse.author)
+        SampleImageModel(sampleResponse.download_url, sampleResponse.author)
     }
 }

--- a/core/data/src/main/java/team/ppac/data/mapper/SampleMapper.kt
+++ b/core/data/src/main/java/team/ppac/data/mapper/SampleMapper.kt
@@ -3,7 +3,7 @@ package team.ppac.data.mapper
 import team.ppac.domain.model.SampleImageModel
 import team.ppac.remote.model.sample.SampleResponse
 
-internal fun List<SampleResponse>.toDomain(): List<SampleImageModel> {
+internal fun List<SampleResponse>.toSampleImageModel(): List<SampleImageModel> {
     return this.map { sampleResponse ->
         SampleImageModel(sampleResponse.download_url, sampleResponse.author)
     }

--- a/core/data/src/main/java/team/ppac/data/mapper/SampleMapper.kt
+++ b/core/data/src/main/java/team/ppac/data/mapper/SampleMapper.kt
@@ -1,0 +1,10 @@
+package team.ppac.data.mapper
+
+import team.ppac.domain.model.SampleImageModel
+import team.ppac.remote.model.sample.SampleResponse
+
+internal fun List<SampleResponse>.toDomain(): List<SampleImageModel> {
+    return this.map { sampleResponse ->
+        SampleImageModel(sampleResponse.url, sampleResponse.author)
+    }
+}

--- a/core/data/src/main/java/team/ppac/data/repository/SampleRepositoryImpl.kt
+++ b/core/data/src/main/java/team/ppac/data/repository/SampleRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package team.ppac.data.repository
 
+import team.ppac.data.mapper.toDomain
 import team.ppac.domain.model.SampleImageModel
 import team.ppac.domain.repository.SampleRepository
 import team.ppac.remote.datasource.SampleDataSource
@@ -9,8 +10,6 @@ internal class SampleRepositoryImpl @Inject constructor(
     private val sampleDataSource: SampleDataSource
 ) : SampleRepository {
     override suspend fun getImages(): List<SampleImageModel> {
-        return sampleDataSource.getImages().map { sampleResponse ->
-            SampleImageModel(sampleResponse.url)
-        }
+        return sampleDataSource.getImages().toDomain()
     }
 }

--- a/core/data/src/main/java/team/ppac/data/repository/SampleRepositoryImpl.kt
+++ b/core/data/src/main/java/team/ppac/data/repository/SampleRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package team.ppac.data.repository
 
-import team.ppac.data.mapper.toDomain
+import team.ppac.data.mapper.toSampleImageModel
 import team.ppac.domain.model.SampleImageModel
 import team.ppac.domain.repository.SampleRepository
 import team.ppac.remote.datasource.SampleDataSource
@@ -10,6 +10,6 @@ internal class SampleRepositoryImpl @Inject constructor(
     private val sampleDataSource: SampleDataSource
 ) : SampleRepository {
     override suspend fun getImages(): List<SampleImageModel> {
-        return sampleDataSource.getImages().toDomain()
+        return sampleDataSource.getImages().toSampleImageModel()
     }
 }

--- a/core/domain/src/main/java/team/ppac/domain/model/SampleImageModel.kt
+++ b/core/domain/src/main/java/team/ppac/domain/model/SampleImageModel.kt
@@ -1,3 +1,6 @@
 package team.ppac.domain.model
 
-data class SampleImageModel(val imageUrl: String)
+data class SampleImageModel(
+    val imageUrl: String,
+    val author: String,
+)

--- a/feature/onboard/src/main/java/team/ppac/onboard/OnboardActivity.kt
+++ b/feature/onboard/src/main/java/team/ppac/onboard/OnboardActivity.kt
@@ -15,4 +15,4 @@ class OnboardActivity : ComponentActivity() {
             LoginScreen(viewModel = hiltViewModel())
         }
     }
-}`
+}

--- a/feature/sample/src/main/java/team/ppac/sample/SampleScreen.kt
+++ b/feature/sample/src/main/java/team/ppac/sample/SampleScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import team.ppac.sample.mvi.SampleIntent
@@ -28,6 +29,13 @@ fun SampleScreen(viewModel: SampleViewModel) {
             },
         ) {
             Text("이미지 로드")
+        }
+
+        if (state.isLoading) {
+            Text(
+                fontSize = 30.sp,
+                text = "로딩중",
+            )
         }
 
         LazyColumn {

--- a/feature/sample/src/main/java/team/ppac/sample/SampleScreen.kt
+++ b/feature/sample/src/main/java/team/ppac/sample/SampleScreen.kt
@@ -2,15 +2,26 @@ package team.ppac.sample
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
 import team.ppac.sample.mvi.SampleIntent
 
 @Composable
 fun SampleScreen(viewModel: SampleViewModel) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         Button(
             onClick = {
                 viewModel.intent(SampleIntent.ClickGetImagesButton)
@@ -19,6 +30,13 @@ fun SampleScreen(viewModel: SampleViewModel) {
             Text("이미지 로드")
         }
 
-
+        LazyColumn {
+            items(items = state.images) {
+                AsyncImage(
+                    model = it.imageUrl,
+                    contentDescription = it.author,
+                )
+            }
+        }
     }
 }

--- a/feature/sample/src/main/java/team/ppac/sample/SampleViewModel.kt
+++ b/feature/sample/src/main/java/team/ppac/sample/SampleViewModel.kt
@@ -8,7 +8,6 @@ import team.ppac.domain.usecase.SampleUseCase
 import team.ppac.sample.mvi.SampleIntent
 import team.ppac.sample.mvi.SampleSideEffect
 import team.ppac.sample.mvi.SampleState
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -23,8 +22,9 @@ class SampleViewModel @Inject constructor(
 
     private fun getImages() {
         viewModelScope.launch {
-            sampleUseCase.getImages().map { imageModel ->
-                Timber.tag("GetImagesTest").d(imageModel.imageUrl)
+            val images = sampleUseCase.getImages()
+            reduce {
+                copy(images = images)
             }
         }
     }

--- a/feature/sample/src/main/java/team/ppac/sample/SampleViewModel.kt
+++ b/feature/sample/src/main/java/team/ppac/sample/SampleViewModel.kt
@@ -20,12 +20,20 @@ class SampleViewModel @Inject constructor(
         }
     }
 
+    private fun updateLoading(isLoading: Boolean) {
+        reduce {
+            copy(isLoading = isLoading)
+        }
+    }
+
     private fun getImages() {
         viewModelScope.launch {
+            updateLoading(true)
             val images = sampleUseCase.getImages()
             reduce {
                 copy(images = images)
             }
+            updateLoading(false)
         }
     }
 }

--- a/feature/sample/src/main/java/team/ppac/sample/mvi/SampleState.kt
+++ b/feature/sample/src/main/java/team/ppac/sample/mvi/SampleState.kt
@@ -4,6 +4,6 @@ import team.ppac.base.UiState
 import team.ppac.domain.model.SampleImageModel
 
 data class SampleState(
-    val isLoading: Boolean = true,
+    val isLoading: Boolean = false,
     val images: List<SampleImageModel> = emptyList(),
 ) : UiState

--- a/feature/sample/src/main/java/team/ppac/sample/mvi/SampleState.kt
+++ b/feature/sample/src/main/java/team/ppac/sample/mvi/SampleState.kt
@@ -1,5 +1,9 @@
 package team.ppac.sample.mvi
 
 import team.ppac.base.UiState
+import team.ppac.domain.model.SampleImageModel
 
-class SampleState() : UiState
+data class SampleState(
+    val isLoading: Boolean = true,
+    val images: List<SampleImageModel> = emptyList(),
+) : UiState


### PR DESCRIPTION
### Issue
- close #14 

### 작업 내역 (Required)
- LazyColumn에 Sample API 데이터 뿌리기 구현

### Screenshot
https://github.com/mash-up-kr/ppac-android/assets/58066704/469eebe0-0de2-4438-8f99-5602673b0207
