### PR TITLE
[Feature] detail bottombar 리플적용

### DIFF
--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailBottomBar.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailBottomBar.kt
@@ -1,5 +1,7 @@
 package team.ppac.detail.component
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -9,21 +11,40 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Text
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import team.ppac.common.android.util.shareOneLink
 import team.ppac.designsystem.FarmemeTheme
 import team.ppac.designsystem.component.tabbar.TabBar
 import team.ppac.designsystem.foundation.FarmemeIcon
-import team.ppac.designsystem.util.extension.noRippleClickable
+import team.ppac.designsystem.foundation.FarmemeRadius
 
 @Composable
 internal fun DetailBottomBar(memeId: String) {
     val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+
+    val originalColor = FarmemeTheme.textColor.primary
+    val selectedColor = FarmemeTheme.textColor.brand
+
+    var copyButtonColor by remember { mutableStateOf(originalColor) }
+    var farmemeButtonChecked by remember { mutableStateOf(false) }
+    val farmemeButtonColor = if (farmemeButtonChecked) selectedColor else originalColor
+
     TabBar(modifier = Modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier
@@ -33,9 +54,18 @@ internal fun DetailBottomBar(memeId: String) {
         ) {
             DetailBottomButton(
                 title = "복사",
-                onClickButton = {},
+                color = copyButtonColor,
+                onClickButton = {
+                    copyButtonColor = selectedColor
+                    coroutineScope.launch {
+                        delay(2000)
+                        copyButtonColor = originalColor
+                    }
+                },
             ) {
-                FarmemeIcon.Copy(modifier = Modifier.size(20.dp))
+                FarmemeIcon.Copy(
+                    modifier = Modifier.size(20.dp), tint = copyButtonColor
+                )
             }
             DetailBottomButton(
                 title = "공유",
@@ -44,10 +74,16 @@ internal fun DetailBottomBar(memeId: String) {
                 FarmemeIcon.Share(modifier = Modifier.size(20.dp))
             }
             DetailBottomButton(
-                title = "북마크",
-                onClickButton = {},
+                title = "파밈",
+                color = farmemeButtonColor,
+                onClickButton = {
+                    farmemeButtonChecked = !farmemeButtonChecked
+                },
             ) {
-                FarmemeIcon.BookmarkLine(modifier = Modifier.size(20.dp))
+                FarmemeIcon.BookmarkLine(
+                    modifier = Modifier.size(20.dp),
+                    tint = farmemeButtonColor,
+                )
             }
         }
     }
@@ -56,13 +92,19 @@ internal fun DetailBottomBar(memeId: String) {
 @Composable
 internal fun RowScope.DetailBottomButton(
     title: String,
+    color: Color = FarmemeTheme.textColor.primary,
     onClickButton: () -> Unit,
     icon: @Composable () -> Unit,
 ) {
     Row(
         modifier = Modifier
             .weight(1f)
-            .noRippleClickable(onClick = onClickButton)
+            .clip(shape = FarmemeRadius.Radius10.shape)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = rememberRipple(color = FarmemeTheme.skeletonColor.primary),
+                onClick = { onClickButton() },
+            )
             .padding(vertical = 15.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center,
@@ -72,7 +114,7 @@ internal fun RowScope.DetailBottomButton(
         Text(
             text = title,
             style = FarmemeTheme.typography.body.xLarge.semibold,
-            color = FarmemeTheme.textColor.primary,
+            color = color,
         )
     }
 }

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailBottomBar.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailBottomBar.kt
@@ -1,5 +1,6 @@
 package team.ppac.detail.component
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -45,6 +46,9 @@ internal fun DetailBottomBar(memeId: String) {
     var farmemeButtonChecked by remember { mutableStateOf(false) }
     val farmemeButtonColor = if (farmemeButtonChecked) selectedColor else originalColor
 
+    val animatedCopyButtonColor by animateColorAsState(targetValue = copyButtonColor)
+    val animatedFarmemeButtonColor by animateColorAsState(targetValue = farmemeButtonColor)
+
     TabBar(modifier = Modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier
@@ -54,7 +58,7 @@ internal fun DetailBottomBar(memeId: String) {
         ) {
             DetailBottomButton(
                 title = "복사",
-                color = copyButtonColor,
+                textColor = animatedCopyButtonColor,
                 onClickButton = {
                     copyButtonColor = selectedColor
                     coroutineScope.launch {
@@ -64,7 +68,8 @@ internal fun DetailBottomBar(memeId: String) {
                 },
             ) {
                 FarmemeIcon.Copy(
-                    modifier = Modifier.size(20.dp), tint = copyButtonColor
+                    modifier = Modifier.size(20.dp),
+                    tint = animatedCopyButtonColor,
                 )
             }
             DetailBottomButton(
@@ -75,14 +80,14 @@ internal fun DetailBottomBar(memeId: String) {
             }
             DetailBottomButton(
                 title = "파밈",
-                color = farmemeButtonColor,
+                textColor = animatedFarmemeButtonColor,
                 onClickButton = {
                     farmemeButtonChecked = !farmemeButtonChecked
                 },
             ) {
                 FarmemeIcon.BookmarkLine(
                     modifier = Modifier.size(20.dp),
-                    tint = farmemeButtonColor,
+                    tint = animatedFarmemeButtonColor,
                 )
             }
         }
@@ -92,7 +97,7 @@ internal fun DetailBottomBar(memeId: String) {
 @Composable
 internal fun RowScope.DetailBottomButton(
     title: String,
-    color: Color = FarmemeTheme.textColor.primary,
+    textColor: Color = FarmemeTheme.textColor.primary,
     onClickButton: () -> Unit,
     icon: @Composable () -> Unit,
 ) {
@@ -114,7 +119,7 @@ internal fun RowScope.DetailBottomButton(
         Text(
             text = title,
             style = FarmemeTheme.typography.body.xLarge.semibold,
-            color = color,
+            color = textColor,
         )
     }
 }


### PR DESCRIPTION
### Issue
- close #80

### 작업 내역 (Required)
- detail bottombar 리플적용(잘 안보임)
- 복사: 클릭시 텍스트 색깔 변경 후 돌아옴
- 파밈: 클릭시 텍스트 색깔 유지 -> 이거는 State 상태로 관리해야될것 같아여(수정예정)

### Review Point (Required)
- 지금  compose 내부에 remember로 상태 관리하도록했는데욧
- animation과 같이 상태를 지속적으로 관리할 필요없는건 ui recompostion에 상태 잃어버려도 된다고 판단되는것들?은 부에 remember 로 상태 관리해도 될지 의견이 궁금합니다. 

- 

### Screenshot


https://github.com/user-attachments/assets/41293627-7d65-431e-9f5b-5aa41aa603b4


### 관련 링크
-