### PR TITLE
[Feat] Detail Screen 세부 Ui 수정

### DIFF
--- a/core/common/kotlin/src/main/java/team/ppac/common/kotlin/extension/ListExtension.kt
+++ b/core/common/kotlin/src/main/java/team/ppac/common/kotlin/extension/ListExtension.kt
@@ -1,0 +1,9 @@
+package team.ppac.common.kotlin.extension
+
+fun List<String>.truncateDisplayedList(maxSize: Int): List<String> {
+    return if (this.size > maxSize) {
+        this.subList(0, maxSize)
+    } else {
+        this
+    }
+}

--- a/core/common/kotlin/src/main/java/team/ppac/common/kotlin/extension/StringExtension.kt
+++ b/core/common/kotlin/src/main/java/team/ppac/common/kotlin/extension/StringExtension.kt
@@ -1,0 +1,9 @@
+package team.ppac.common.kotlin.extension
+
+fun String.truncateDisplayedString(maxLength: Int): String {
+    return if (this.length > maxLength) {
+        this.substring(0, maxLength - 1)
+    } else {
+        this
+    }
+}

--- a/core/data/src/main/java/team/ppac/data/repository/MemeRepositoryImpl.kt
+++ b/core/data/src/main/java/team/ppac/data/repository/MemeRepositoryImpl.kt
@@ -26,4 +26,8 @@ class MemeRepositoryImpl @Inject constructor(
         return memeDataSource.deleteSavedMeme(memeId)
     }
 
+    override suspend fun reactMeme(memeId: String): Boolean {
+        return memeDataSource.reactMeme(memeId)
+    }
+
 }

--- a/core/designsystem/src/main/kotlin/team/ppac/designsystem/util/extension/NoRippleClickable.kt
+++ b/core/designsystem/src/main/kotlin/team/ppac/designsystem/util/extension/NoRippleClickable.kt
@@ -3,9 +3,11 @@ package team.ppac.designsystem.util.extension
 import android.annotation.SuppressLint
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.Color
 import team.ppac.common.kotlin.model.MultipleEventsCutter
 
 @SuppressLint("ModifierFactoryUnreferencedReceiver")
@@ -19,6 +21,22 @@ fun Modifier.noRippleClickable(
         indication = null,
         enabled = enabled,
         interactionSource = remember { MutableInteractionSource() },
+        onClick = { multipleEventsCutter.processEvent(onClick) },
+    )
+}
+
+@SuppressLint("ModifierFactoryUnreferencedReceiver")
+fun Modifier.rippleClickable(
+    rippleColor: Color,
+    enabled: Boolean = true,
+    debounceMillis: Long = 300L,
+    onClick: () -> Unit,
+): Modifier = composed {
+    val multipleEventsCutter = remember { MultipleEventsCutter(debounceMillis) }
+    clickable(
+        interactionSource = remember { MutableInteractionSource() },
+        enabled = enabled,
+        indication = rememberRipple(color = rippleColor),
         onClick = { multipleEventsCutter.processEvent(onClick) },
     )
 }

--- a/core/domain/src/main/java/team/ppac/domain/di/UseCaseModule.kt
+++ b/core/domain/src/main/java/team/ppac/domain/di/UseCaseModule.kt
@@ -23,6 +23,8 @@ import team.ppac.domain.usecase.GetUserSavedMemesUseCase
 import team.ppac.domain.usecase.GetUserSavedMemesUseCaseImpl
 import team.ppac.domain.usecase.GetUserUseCase
 import team.ppac.domain.usecase.GetUserUseCaseImpl
+import team.ppac.domain.usecase.ReactMemeUseCase
+import team.ppac.domain.usecase.ReactMemeUseCaseImpl
 import team.ppac.domain.usecase.SampleUseCase
 import team.ppac.domain.usecase.SampleUseCaseImpl
 import team.ppac.domain.usecase.SaveMemeUseCase
@@ -74,4 +76,8 @@ internal abstract class UseCaseModule {
     @Binds
     @ViewModelScoped
     abstract fun bindDeleteSavedMemeUseCase(impl: DeleteSavedMemeUseCaseImpl): DeleteSavedMemeUseCase
+
+    @Binds
+    @ViewModelScoped
+    abstract fun bindReactMemeUseCae(impl: ReactMemeUseCaseImpl): ReactMemeUseCase
 }

--- a/core/domain/src/main/java/team/ppac/domain/repository/MemeRepository.kt
+++ b/core/domain/src/main/java/team/ppac/domain/repository/MemeRepository.kt
@@ -7,4 +7,5 @@ interface MemeRepository {
     suspend fun getRecommendMemes(): List<Meme>
     suspend fun saveMeme(memeId: String): Boolean
     suspend fun deleteSavedMeme(memeId: String): Boolean
+    suspend fun reactMeme(memeId: String): Boolean
 }

--- a/core/domain/src/main/java/team/ppac/domain/usecase/ReactMemeUseCase.kt
+++ b/core/domain/src/main/java/team/ppac/domain/usecase/ReactMemeUseCase.kt
@@ -1,0 +1,16 @@
+package team.ppac.domain.usecase
+
+import team.ppac.domain.repository.MemeRepository
+import javax.inject.Inject
+
+interface ReactMemeUseCase {
+    suspend operator fun invoke(memeId: String): Boolean
+}
+
+internal class ReactMemeUseCaseImpl @Inject constructor(
+    private val memeRepository: MemeRepository,
+) : ReactMemeUseCase {
+    override suspend fun invoke(memeId: String): Boolean {
+        return memeRepository.reactMeme(memeId)
+    }
+}

--- a/core/remote/src/main/kotlin/team/ppac/remote/api/MemeApi.kt
+++ b/core/remote/src/main/kotlin/team/ppac/remote/api/MemeApi.kt
@@ -23,4 +23,7 @@ internal interface MemeApi {
     @DELETE("/api/meme/{memeId}/save")
     suspend fun deleteSavedMeme(@Path("memeId") memeId: String): Boolean
 
+    @POST("/api/meme/{memeId}/reaction")
+    suspend fun reactMeme(@Path("memeId") memeId: String): Boolean
+
 }

--- a/core/remote/src/main/kotlin/team/ppac/remote/datasource/MemeDataSource.kt
+++ b/core/remote/src/main/kotlin/team/ppac/remote/datasource/MemeDataSource.kt
@@ -7,4 +7,5 @@ interface MemeDataSource {
     suspend fun getRecommendMemes(): List<MemeResponse>
     suspend fun saveMeme(memeId: String): Boolean
     suspend fun deleteSavedMeme(memeId: String): Boolean
+    suspend fun reactMeme(memeId: String): Boolean
 }

--- a/core/remote/src/main/kotlin/team/ppac/remote/datasource/impl/MemeDataSourceImpl.kt
+++ b/core/remote/src/main/kotlin/team/ppac/remote/datasource/impl/MemeDataSourceImpl.kt
@@ -23,4 +23,8 @@ internal class MemeDataSourceImpl @Inject constructor(
     override suspend fun deleteSavedMeme(memeId: String): Boolean {
         return memeApi.deleteSavedMeme(memeId)
     }
+
+    override suspend fun reactMeme(memeId: String): Boolean {
+        return memeApi.reactMeme(memeId)
+    }
 }

--- a/feature/detail/src/main/java/team/ppac/detail/DetailActivity.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailActivity.kt
@@ -14,7 +14,7 @@ class DetailActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             FarmemeTheme {
-                DetailRoute()
+                DetailRoute(navigateToBack = { finish() })
             }
         }
     }

--- a/feature/detail/src/main/java/team/ppac/detail/DetailRoute.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailRoute.kt
@@ -1,12 +1,28 @@
 package team.ppac.detail
 
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.LottieCompositionSpec
+import com.airbnb.lottie.compose.rememberLottieAnimatable
+import com.airbnb.lottie.compose.rememberLottieComposition
+import kotlinx.coroutines.launch
+import team.ppac.designsystem.R
 import team.ppac.detail.mvi.DetailIntent
+import team.ppac.detail.mvi.DetailSideEffect
+import kotlin.math.roundToInt
 
 @Composable
 internal fun DetailRoute(
@@ -15,11 +31,23 @@ internal fun DetailRoute(
 ) {
 
     val uiState by viewModel.state.collectAsStateWithLifecycle()
+    val lottieComposition by rememberLottieComposition(
+        LottieCompositionSpec.RawRes(R.raw.lol_rising_effect)
+    )
+    val lottieAnimatable = rememberLottieAnimatable()
+    var lottiePosition by remember { mutableStateOf(Offset.Zero) }
 
     LaunchedEffect(key1 = viewModel) {
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
-                else -> {}
+                is DetailSideEffect.RunRisingEffect -> {
+                    launch {
+                        lottieAnimatable.animate(
+                            composition = lottieComposition,
+                            speed = 1.5f
+                        )
+                    }
+                }
             }
         }
     }
@@ -33,6 +61,27 @@ internal fun DetailRoute(
                     isSavedMeme = isSavedMeme
                 )
             )
+        },
+        onClickFunnyButton = {
+            viewModel.intent(DetailIntent.ClickFunnyButton)
+        },
+        onReactionButtonPosition = {
+            lottiePosition = it
         }
+    )
+    LottieAnimation(
+        modifier = Modifier
+            .size(200.dp)
+            .offset {
+                with(lottiePosition) {
+                    // ㅋㅋ 버튼의 좌상단 기준으로 사이즈 참고하여 Offset 위치 조정
+                    IntOffset(
+                        x = x.roundToInt() + 42.dp.roundToPx(),
+                        y = y.roundToInt() - 192.dp.roundToPx()
+                    )
+                }
+            },
+        composition = lottieComposition,
+        progress = { lottieAnimatable.progress },
     )
 }

--- a/feature/detail/src/main/java/team/ppac/detail/DetailRoute.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailRoute.kt
@@ -27,7 +27,8 @@ import kotlin.math.roundToInt
 @Composable
 internal fun DetailRoute(
     modifier: Modifier = Modifier,
-    viewModel: DetailViewModel = hiltViewModel()
+    viewModel: DetailViewModel = hiltViewModel(),
+    navigateToBack: () -> Unit,
 ) {
 
     val uiState by viewModel.state.collectAsStateWithLifecycle()
@@ -48,6 +49,10 @@ internal fun DetailRoute(
                         )
                     }
                 }
+
+                is DetailSideEffect.NavigateToBackEffect -> {
+                    navigateToBack()
+                }
             }
         }
     }
@@ -67,7 +72,11 @@ internal fun DetailRoute(
         },
         onReactionButtonPosition = {
             lottiePosition = it
+        },
+        onClickBackButton = {
+            viewModel.intent(DetailIntent.ClickBackButton)
         }
+
     )
     LottieAnimation(
         modifier = Modifier

--- a/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
@@ -1,6 +1,8 @@
 package team.ppac.detail
 
 import android.graphics.Bitmap
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
@@ -8,11 +10,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
 import team.ppac.common.android.util.copyImageToClipBoard
 import team.ppac.designsystem.component.scaffold.FarmemeScaffold
@@ -62,15 +64,19 @@ internal fun DetailScreen(
             )
         },
     ) { innerPadding ->
-        DetailContent(
+        Box(
             modifier = Modifier
                 .padding(innerPadding)
-                .padding(top = 31.dp, bottom = 44.dp),
-            uiModel = uiState.detailMemeUiModel,
-            saveBitmap = saveBitmap,
-            onClickFunnyButton = onClickFunnyButton,
-            onReactionButtonPositioned = onReactionButtonPosition,
-        )
+                .fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            DetailContent(
+                uiModel = uiState.detailMemeUiModel,
+                saveBitmap = saveBitmap,
+                onClickFunnyButton = onClickFunnyButton,
+                onReactionButtonPositioned = onReactionButtonPosition,
+            )
+        }
     }
 }
 

--- a/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
@@ -31,6 +31,7 @@ internal fun DetailScreen(
     onClickFarmemeButton: (Boolean) -> Unit,
     onClickFunnyButton: () -> Unit,
     onReactionButtonPosition: (Offset) -> Unit,
+    onClickBackButton: () -> Unit,
 ) {
 
     var context = LocalContext.current
@@ -52,7 +53,7 @@ internal fun DetailScreen(
         topBar = {
             FarmemeBackToolBar(
                 title = "밈 자세히 보기",
-                onClickBackIcon = {}
+                onClickBackIcon = onClickBackButton,
             )
         },
         bottomBar = {
@@ -97,6 +98,7 @@ fun PreviewDetailScreen() {
         ),
         onClickFarmemeButton = {},
         onClickFunnyButton = {},
-        onReactionButtonPosition = { _ -> }
+        onReactionButtonPosition = { _ -> },
+        onClickBackButton = {},
     )
 }

--- a/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -26,6 +27,8 @@ internal fun DetailScreen(
     modifier: Modifier = Modifier,
     uiState: DetailUiState,
     onClickFarmemeButton: (Boolean) -> Unit,
+    onClickFunnyButton: () -> Unit,
+    onReactionButtonPosition: (Offset) -> Unit,
 ) {
 
     var context = LocalContext.current
@@ -64,7 +67,9 @@ internal fun DetailScreen(
                 .padding(innerPadding)
                 .padding(top = 31.dp, bottom = 44.dp),
             uiModel = uiState.detailMemeUiModel,
-            saveBitmap = saveBitmap
+            saveBitmap = saveBitmap,
+            onClickFunnyButton = onClickFunnyButton,
+            onReactionButtonPositioned = onReactionButtonPosition,
         )
     }
 }
@@ -80,9 +85,12 @@ fun PreviewDetailScreen() {
                 name = "나는 공부를 찢어",
                 hashTags = persistentListOf("#공부", "#학생", "#시험기간", "#힘듦", "#피곤"),
                 sourceDescription = "출처에 대한 내용이 들어갑니다.",
-                isSavedMeme = false
+                isSavedMeme = false,
+                reactionCount = 0,
             ),
         ),
         onClickFarmemeButton = {},
+        onClickFunnyButton = {},
+        onReactionButtonPosition = { _ -> }
     )
 }

--- a/feature/detail/src/main/java/team/ppac/detail/DetailViewModel.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailViewModel.kt
@@ -48,7 +48,7 @@ class DetailViewModel @Inject constructor(
                 postSideEffect(DetailSideEffect.RunRisingEffect)
             }
 
-            DetailIntent.ClickBackButton -> {
+            is DetailIntent.ClickBackButton -> {
                 postSideEffect(DetailSideEffect.NavigateToBackEffect)
             }
         }
@@ -91,7 +91,6 @@ class DetailViewModel @Inject constructor(
 
     private fun incrementReactionCount() {
         viewModelScope.launch {
-            reactMemeUseCase(currentState.memeId)
             reduce {
                 copy(
                     detailMemeUiModel = detailMemeUiModel.copy(
@@ -99,6 +98,14 @@ class DetailViewModel @Inject constructor(
                     )
                 )
             }
+
+            reduce {
+                copy(
+                    detailMemeUiModel = detailMemeUiModel.copy(
+                        reactionCount = detailMemeUiModel.reactionCount - 1
+                    )
+                )
+            }.takeIf { !reactMemeUseCase(currentState.memeId) }
         }
     }
 

--- a/feature/detail/src/main/java/team/ppac/detail/DetailViewModel.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailViewModel.kt
@@ -45,6 +45,10 @@ class DetailViewModel @Inject constructor(
                 incrementReactionCount()
                 postSideEffect(DetailSideEffect.RunRisingEffect)
             }
+
+            DetailIntent.ClickBackButton -> {
+                postSideEffect(DetailSideEffect.NavigateToBackEffect)
+            }
         }
     }
 

--- a/feature/detail/src/main/java/team/ppac/detail/DetailViewModel.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailViewModel.kt
@@ -40,6 +40,11 @@ class DetailViewModel @Inject constructor(
                     saveMeme()
                 }
             }
+
+            is DetailIntent.ClickFunnyButton -> {
+                incrementReactionCount()
+                postSideEffect(DetailSideEffect.RunRisingEffect)
+            }
         }
     }
 
@@ -56,8 +61,7 @@ class DetailViewModel @Inject constructor(
             if (isSaveSuccess) {
                 reduce {
                     copy(
-                        detailMemeUiModel = currentState
-                            .detailMemeUiModel
+                        detailMemeUiModel = detailMemeUiModel
                             .copy(isSavedMeme = true)
                     )
                 }
@@ -71,12 +75,21 @@ class DetailViewModel @Inject constructor(
             if (isSaveSuccess) {
                 reduce {
                     copy(
-                        detailMemeUiModel = currentState
-                            .detailMemeUiModel
+                        detailMemeUiModel = detailMemeUiModel
                             .copy(isSavedMeme = false)
                     )
                 }
             }
+        }
+    }
+
+    private fun incrementReactionCount() {
+        reduce {
+            copy(
+                detailMemeUiModel = detailMemeUiModel.copy(
+                    reactionCount = detailMemeUiModel.reactionCount + 1
+                )
+            )
         }
     }
 

--- a/feature/detail/src/main/java/team/ppac/detail/DetailViewModel.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailViewModel.kt
@@ -11,6 +11,7 @@ import team.ppac.detail.mvi.DetailSideEffect
 import team.ppac.detail.mvi.DetailUiState
 import team.ppac.domain.usecase.DeleteSavedMemeUseCase
 import team.ppac.domain.usecase.GetMemeUseCase
+import team.ppac.domain.usecase.ReactMemeUseCase
 import team.ppac.domain.usecase.SaveMemeUseCase
 import javax.inject.Inject
 
@@ -20,6 +21,7 @@ class DetailViewModel @Inject constructor(
     private val getMemeUseCase: GetMemeUseCase,
     private val saveMemeUseCase: SaveMemeUseCase,
     private val deleteSavedMemeUseCase: DeleteSavedMemeUseCase,
+    private val reactMemeUseCase: ReactMemeUseCase,
 ) : BaseViewModel<DetailUiState, DetailSideEffect, DetailIntent>(savedStateHandle) {
 
     init {
@@ -88,12 +90,15 @@ class DetailViewModel @Inject constructor(
     }
 
     private fun incrementReactionCount() {
-        reduce {
-            copy(
-                detailMemeUiModel = detailMemeUiModel.copy(
-                    reactionCount = detailMemeUiModel.reactionCount + 1
+        viewModelScope.launch {
+            reactMemeUseCase(currentState.memeId)
+            reduce {
+                copy(
+                    detailMemeUiModel = detailMemeUiModel.copy(
+                        reactionCount = detailMemeUiModel.reactionCount + 1
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailBottomBar.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailBottomBar.kt
@@ -33,6 +33,7 @@ import team.ppac.designsystem.FarmemeTheme
 import team.ppac.designsystem.component.tabbar.TabBar
 import team.ppac.designsystem.foundation.FarmemeIcon
 import team.ppac.designsystem.foundation.FarmemeRadius
+import team.ppac.designsystem.util.extension.rippleClickable
 
 @Composable
 internal fun DetailBottomBar(
@@ -111,11 +112,9 @@ internal fun RowScope.DetailBottomButton(
         modifier = Modifier
             .weight(1f)
             .clip(shape = FarmemeRadius.Radius10.shape)
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = rememberRipple(color = FarmemeTheme.skeletonColor.primary),
-                onClick = { onClickButton() },
-            )
+            .rippleClickable(
+                rippleColor = FarmemeTheme.skeletonColor.secondary,
+                onClick = onClickButton)
             .padding(vertical = 15.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center,

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -52,7 +52,7 @@ import team.ppac.detail.mvi.DetailUiState
 
 @Composable
 internal fun DetailContent(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     uiModel: DetailMemeUiModel,
     saveBitmap: (Bitmap) -> Unit,
     onClickFunnyButton: () -> Unit,
@@ -84,6 +84,7 @@ internal fun DetailContent(
                 onClickFunnyButton = onClickFunnyButton,
                 onReactionButtonPositioned = onReactionButtonPositioned
             )
+            Spacer(modifier = Modifier.height(10.dp))
         }
     }
 }
@@ -104,7 +105,9 @@ private fun DetailImage(
             contentDescription = null,
             contentScale = ContentScale.Crop,
             modifier = Modifier
-                .clip(FarmemeRadius.Radius10.shape),
+                .clip(FarmemeRadius.Radius10.shape)
+                .width(330.dp)
+                .height(352.dp),
             onSuccess = { saveBitmap(it.result.drawable.toBitmap()) }
         )
         Box(

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -29,7 +29,7 @@ import team.ppac.designsystem.FarmemeTheme
 import team.ppac.designsystem.R
 import team.ppac.designsystem.foundation.FarmemeIcon
 import team.ppac.designsystem.foundation.FarmemeRadius
-import team.ppac.designsystem.util.extension.noRippleClickable
+import team.ppac.designsystem.util.extension.rippleClickable
 import team.ppac.detail.model.DetailMemeUiModel
 import team.ppac.detail.mvi.DetailUiState
 
@@ -119,7 +119,10 @@ fun DetailFunnyButton() {
             .height(46.dp)
             .clip(FarmemeRadius.Radius10.shape)
             .background(color = FarmemeTheme.skeletonColor.primary)
-            .noRippleClickable(onClick = {}),
+            .rippleClickable(
+                rippleColor = FarmemeTheme.skeletonColor.secondary,
+                onClick = {}
+            ),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center,
     ) {

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -23,6 +23,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -67,17 +70,9 @@ internal fun DetailContent(
             modifier = Modifier.padding(10.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            AsyncImage(
-                model = ImageRequest
-                    .Builder(LocalContext.current)
-                    .data(uiModel.imageUrl)
-                    .crossfade(true)
-                    .build(),
-                placeholder = painterResource(R.drawable.detail_sample),
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.clip(FarmemeRadius.Radius10.shape),
-                onSuccess = { saveBitmap(it.result.drawable.toBitmap()) }
+            DetailImage(
+                imageUrl = uiModel.imageUrl,
+                saveBitmap = saveBitmap,
             )
             DetailHashTags(
                 name = uiModel.name,
@@ -90,6 +85,41 @@ internal fun DetailContent(
                 onReactionButtonPositioned = onReactionButtonPositioned
             )
         }
+    }
+}
+
+@Composable
+private fun DetailImage(
+    imageUrl: String,
+    saveBitmap: (Bitmap) -> Unit
+) {
+    Box {
+        AsyncImage(
+            model = ImageRequest
+                .Builder(LocalContext.current)
+                .data(imageUrl)
+                .crossfade(true)
+                .build(),
+            placeholder = painterResource(R.drawable.detail_sample),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .clip(FarmemeRadius.Radius10.shape),
+            onSuccess = { saveBitmap(it.result.drawable.toBitmap()) }
+        )
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .graphicsLayer(alpha = 0.80f)
+                .clip(FarmemeRadius.Radius10.shape)
+                .background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(Color.Transparent, FarmemeTheme.iconColor.secondary),
+                        startY = 320f,
+                        endY = 1000f
+                    )
+                )
+        )
     }
 }
 

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -41,7 +41,10 @@ import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.rememberLottieAnimatable
 import com.airbnb.lottie.compose.rememberLottieComposition
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.launch
+import team.ppac.common.kotlin.extension.truncateDisplayedString
+import team.ppac.common.kotlin.extension.truncateDisplayedList
 import team.ppac.designsystem.FarmemeTheme
 import team.ppac.designsystem.R
 import team.ppac.designsystem.foundation.FarmemeIcon
@@ -130,21 +133,21 @@ private fun DetailImage(
 internal fun DetailHashTags(
     name: String,
     sourceDescription: String,
-    hashTags: List<String>,
+    hashTags: ImmutableList<String>,
 ) {
 
     Spacer(modifier = Modifier.height(25.dp))
     Text(
-        text = name.truncateDisplayedName(16),
+        text = name.truncateDisplayedString(16),
         color = FarmemeTheme.textColor.primary,
         style = FarmemeTheme.typography.heading.large.semibold,
         overflow = TextOverflow.Ellipsis
     )
     Spacer(modifier = Modifier.height(5.dp))
-    DetailTags(hashTags = hashTags.truncateDisplayedTags(6))
+    DetailTags(hashTags = hashTags.truncateDisplayedList(6))
     Spacer(modifier = Modifier.height(11.dp))
     Text(
-        text = "출처: $sourceDescription".truncateDisplayedName(32),
+        text = "출처: $sourceDescription".truncateDisplayedString(32),
         color = FarmemeTheme.textColor.assistive,
         style = FarmemeTheme.typography.body.xSmall.medium,
         maxLines = 1,
@@ -227,22 +230,6 @@ fun DetailFunnyButton(
                 )
             }
         }
-    }
-}
-
-private fun String.truncateDisplayedName(maxLength: Int): String {
-    return if (this.length > maxLength) {
-        this.substring(0, maxLength - 1)
-    } else {
-        this
-    }
-}
-
-private fun List<String>.truncateDisplayedTags(maxSize: Int): List<String> {
-    return if (this.size > maxSize) {
-        this.subList(0, maxSize)
-    } else {
-        this
     }
 }
 

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.drawable.toBitmap
@@ -98,19 +99,23 @@ internal fun DetailHashTags(
     sourceDescription: String,
     hashTags: List<String>,
 ) {
+
     Spacer(modifier = Modifier.height(25.dp))
     Text(
-        text = name,
+        text = name.truncateDisplayedName(16),
         color = FarmemeTheme.textColor.primary,
         style = FarmemeTheme.typography.heading.large.semibold,
+        overflow = TextOverflow.Ellipsis
     )
     Spacer(modifier = Modifier.height(5.dp))
-    DetailTags(hashTags = hashTags)
+    DetailTags(hashTags = hashTags.truncateDisplayedTags(6))
     Spacer(modifier = Modifier.height(11.dp))
     Text(
-        text = "출처: $sourceDescription",
+        text = "출처: $sourceDescription".truncateDisplayedName(32),
         color = FarmemeTheme.textColor.assistive,
         style = FarmemeTheme.typography.body.xSmall.medium,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis
     )
     Spacer(modifier = Modifier.height(20.dp))
 }
@@ -120,7 +125,7 @@ internal fun DetailTags(hashTags: List<String>) {
     Row {
         hashTags.forEach { hashTag ->
             Text(
-                text = hashTag,
+                text = "#$hashTag",
                 color = FarmemeTheme.textColor.tertiary,
                 style = FarmemeTheme.typography.body.large.medium,
             )
@@ -189,6 +194,22 @@ fun DetailFunnyButton(
                 )
             }
         }
+    }
+}
+
+private fun String.truncateDisplayedName(maxLength: Int): String {
+    return if (this.length > maxLength) {
+        this.substring(0, maxLength - 1)
+    } else {
+        this
+    }
+}
+
+private fun List<String>.truncateDisplayedTags(maxSize: Int): List<String> {
+    return if (this.size > maxSize) {
+        this.subList(0, maxSize)
+    } else {
+        this
     }
 }
 

--- a/feature/detail/src/main/java/team/ppac/detail/mapper/DetailUiModelMapper.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/mapper/DetailUiModelMapper.kt
@@ -10,4 +10,5 @@ internal fun Meme.toDetailMemeUiModel(): DetailMemeUiModel = DetailMemeUiModel(
     hashTags = keywords.map { it.name }.toImmutableList(),
     sourceDescription = source,
     isSavedMeme = isSaved,
+    reactionCount = reaction,
 )

--- a/feature/detail/src/main/java/team/ppac/detail/model/DetailMemeUiModel.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/model/DetailMemeUiModel.kt
@@ -8,4 +8,5 @@ data class DetailMemeUiModel(
     val hashTags: ImmutableList<String>,
     val sourceDescription: String,
     val isSavedMeme: Boolean,
+    val reactionCount: Int,
 )

--- a/feature/detail/src/main/java/team/ppac/detail/mvi/DetailIntent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/mvi/DetailIntent.kt
@@ -6,4 +6,6 @@ sealed class DetailIntent : UiIntent {
     data class ClickFarmemeButton(
         val isSavedMeme: Boolean,
     ) : DetailIntent()
+
+    data object ClickFunnyButton : DetailIntent()
 }

--- a/feature/detail/src/main/java/team/ppac/detail/mvi/DetailIntent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/mvi/DetailIntent.kt
@@ -8,4 +8,6 @@ sealed class DetailIntent : UiIntent {
     ) : DetailIntent()
 
     data object ClickFunnyButton : DetailIntent()
+
+    data object ClickBackButton : DetailIntent()
 }

--- a/feature/detail/src/main/java/team/ppac/detail/mvi/DetailSideEffect.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/mvi/DetailSideEffect.kt
@@ -2,4 +2,6 @@ package team.ppac.detail.mvi
 
 import team.ppac.common.android.base.UiSideEffect
 
-sealed class DetailSideEffect : UiSideEffect
+sealed class DetailSideEffect : UiSideEffect {
+    data object RunRisingEffect : DetailSideEffect()
+}

--- a/feature/detail/src/main/java/team/ppac/detail/mvi/DetailSideEffect.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/mvi/DetailSideEffect.kt
@@ -4,4 +4,5 @@ import team.ppac.common.android.base.UiSideEffect
 
 sealed class DetailSideEffect : UiSideEffect {
     data object RunRisingEffect : DetailSideEffect()
+    data object NavigateToBackEffect: DetailSideEffect()
 }

--- a/feature/detail/src/main/java/team/ppac/detail/mvi/DetailUiState.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/mvi/DetailUiState.kt
@@ -18,6 +18,7 @@ data class DetailUiState(
                 hashTags = persistentListOf(),
                 sourceDescription = "",
                 isSavedMeme = false,
+                reactionCount = 0,
             )
         )
     }

--- a/feature/detail/src/main/java/team/ppac/detail/mvi/DetailUiState.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/mvi/DetailUiState.kt
@@ -14,9 +14,9 @@ data class DetailUiState(
             memeId = "",
             detailMemeUiModel = DetailMemeUiModel(
                 imageUrl = "",
-                name = "",
-                hashTags = persistentListOf(),
-                sourceDescription = "",
+                name = "나느 공부를 찢어 나는 공부를 찢어 나는 공부를 찢어",
+                hashTags = persistentListOf("공부", "배고파", "졸려", "심심해", "우울", "힘듦", "배고파"),
+                sourceDescription = "이곳에는 출처에 대한 내용이 들어갑니다. 이곳에는 출처에 대한 내용이 들어갑니다.",
                 isSavedMeme = false,
                 reactionCount = 0,
             )

--- a/feature/recommendation/src/main/java/team/ppac/recommendation/RecommendationScreen.kt
+++ b/feature/recommendation/src/main/java/team/ppac/recommendation/RecommendationScreen.kt
@@ -134,6 +134,7 @@ internal fun RecommendationScreen(
                 )
             }
         }
+
         LottieAnimation(
             modifier = Modifier
                 .size(200.dp)


### PR DESCRIPTION
### Issue
- close #98 

### 작업 내역 (Required)
- Ripple 색상 있는거 공통으로 사용할수 있도록 확장함수로 구현
- ㅋㅋㅋ 로띠 적용 및 react api 연결
- Detail 밈 설명 텍스트 길이 제한
- Detail 밈 이미지 그라데이션 구현
- Detail Screen content 중앙 정렬
- Detail Screen AppBar에 navigatBack 적용


### Review Point (Required)

### Screenshot
https://github.com/user-attachments/assets/831a4373-8bc0-417e-920d-0244b1f7e367


### 관련 링크
-