### PR TITLE
검색 화면에서 밈 조회 API 연결

### DIFF
--- a/feature/search/src/main/java/team/ppac/search/detail/SearchDetailRoute.kt
+++ b/feature/search/src/main/java/team/ppac/search/detail/SearchDetailRoute.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import team.ppac.common.android.base.BaseComposable
 import team.ppac.designsystem.foundation.FarmemeIcon
+import team.ppac.search.detail.mvi.SearchDetailIntent
+import team.ppac.search.detail.mvi.SearchDetailSideEffect
 
 @Composable
 internal fun SearchDetailRoute(
@@ -20,7 +22,8 @@ internal fun SearchDetailRoute(
         LaunchedEffect(key1 = viewModel) {
             viewModel.sideEffect.collect { sideEffect ->
                 when (sideEffect) {
-                    else -> {}
+                    is SearchDetailSideEffect.NavigateToMemeDetail ->
+                        navigateToMemeDetail(sideEffect.memeId)
                 }
             }
         }
@@ -29,7 +32,7 @@ internal fun SearchDetailRoute(
             modifier = modifier,
             uiState = uiState,
             onBackClick = navigateBack,
-            onMemeClick = navigateToMemeDetail,
+            onMemeClick = { viewModel.intent(SearchDetailIntent.ClickMeme(it)) },
             onCopyClick = {
                 viewModel.showSnackbar(
                     message = "이미지를 클립보드에 복사했어요",

--- a/feature/search/src/main/java/team/ppac/search/detail/SearchDetailViewModel.kt
+++ b/feature/search/src/main/java/team/ppac/search/detail/SearchDetailViewModel.kt
@@ -7,7 +7,9 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import team.ppac.common.android.base.BaseViewModel
+import team.ppac.domain.model.MemeWatchType
 import team.ppac.domain.usecase.GetSearchMemeUseCase
+import team.ppac.domain.usecase.WatchMemeUseCase
 import team.ppac.search.detail.model.toSearchResultUiModel
 import team.ppac.search.detail.mvi.SearchDetailIntent
 import team.ppac.search.detail.mvi.SearchDetailSideEffect
@@ -18,6 +20,7 @@ import javax.inject.Inject
 class SearchDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val getSearchMemeUseCase: GetSearchMemeUseCase,
+    private val watchMemeUseCase: WatchMemeUseCase,
 ) : BaseViewModel<SearchDetailUiState, SearchDetailSideEffect, SearchDetailIntent>(savedStateHandle) {
 
     init {
@@ -30,7 +33,20 @@ class SearchDetailViewModel @Inject constructor(
     }
 
     override suspend fun handleIntent(intent: SearchDetailIntent) {
-
+        when (intent) {
+            is SearchDetailIntent.ClickMeme -> {
+                runCatching {
+                    watchMemeUseCase(
+                        memeId = intent.memeId,
+                        watchType = MemeWatchType.SEARCH
+                    )
+                }.onSuccess {
+                    postSideEffect(SearchDetailSideEffect.NavigateToMemeDetail(memeId = intent.memeId))
+                }.onFailure {
+                    // 에러 처리
+                }
+            }
+        }
     }
 
     private fun getSearchResults(memeCategory: String) {

--- a/feature/search/src/main/java/team/ppac/search/detail/mvi/SearchDetailIntent.kt
+++ b/feature/search/src/main/java/team/ppac/search/detail/mvi/SearchDetailIntent.kt
@@ -2,4 +2,8 @@ package team.ppac.search.detail.mvi
 
 import team.ppac.common.android.base.UiIntent
 
-sealed class SearchDetailIntent : UiIntent
+sealed class SearchDetailIntent : UiIntent {
+    data class ClickMeme(
+        val memeId: String,
+    ) : SearchDetailIntent()
+}

--- a/feature/search/src/main/java/team/ppac/search/detail/mvi/SearchDetailSideEffect.kt
+++ b/feature/search/src/main/java/team/ppac/search/detail/mvi/SearchDetailSideEffect.kt
@@ -2,4 +2,8 @@ package team.ppac.search.detail.mvi
 
 import team.ppac.common.android.base.UiSideEffect
 
-sealed class SearchDetailSideEffect : UiSideEffect
+sealed class SearchDetailSideEffect : UiSideEffect {
+    data class NavigateToMemeDetail(
+        val memeId: String,
+    ) : SearchDetailSideEffect()
+}


### PR DESCRIPTION
### Issue
- close #112 

### Pre-Issue
- #93 

### 작업 내역 (Required)
- 밈 모아보기에서 특정 밈 클릭 시 조회 API 호출 후 화면 전환 로직 작성

### Review Point (Required)
- 이거 #93 브랜치에서 피쳐 새로 따서 작업한거긴한데, PR base 브랜치를 feature/keyword-category-api로 하는게 맞나..?? 요런식으로 작업해본게 첨이라..ㅋㅋ

### 관련 링크
- None