### PR TITLE
검색/검색상세 쪽 UI 개선

### DIFF
--- a/core/common/android/src/main/kotlin/team/ppac/common/android/component/FarmemeMemeItem.kt
+++ b/core/common/android/src/main/kotlin/team/ppac/common/android/component/FarmemeMemeItem.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
@@ -66,7 +67,7 @@ fun LazyStaggeredGridItemScope.FarmemeMemeItem(
                     .data(imageUrl)
                     .crossfade(true)
                     .build(),
-//                placeholder = painterResource(id = R.drawable.img_sample),  // TODO(JaesungLeee) : API 연결 후 제거 필요
+                placeholder = ColorPainter(FarmemeTheme.skeletonColor.primary),
                 contentDescription = null,
                 contentScale = ContentScale.FillWidth,
                 onSuccess = {

--- a/core/designsystem/src/main/kotlin/team/ppac/designsystem/component/toolbar/Toolbar.kt
+++ b/core/designsystem/src/main/kotlin/team/ppac/designsystem/component/toolbar/Toolbar.kt
@@ -8,17 +8,16 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsIgnoringVisibility
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -64,14 +63,15 @@ internal fun FarmemeToolbar(
         Row(
             modifier = Modifier
                 .padding(
-                    top = with(LocalDensity.current) {
-                        WindowInsets.statusBarsIgnoringVisibility
-                            .getTop(this)
-                            .toDp()
-                    }
+                    horizontal = 20.dp,
+                    vertical = 15.dp
                 )
-                .fillMaxWidth()
-                .height(50.dp),
+                .padding(
+                    top = WindowInsets.statusBars
+                        .asPaddingValues()
+                        .calculateTopPadding()
+                )
+                .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(

--- a/core/designsystem/src/main/kotlin/team/ppac/designsystem/component/toolbar/Toolbar.kt
+++ b/core/designsystem/src/main/kotlin/team/ppac/designsystem/component/toolbar/Toolbar.kt
@@ -3,14 +3,17 @@
 package team.ppac.designsystem.component.toolbar
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsIgnoringVisibility
+import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -57,46 +60,45 @@ internal fun FarmemeToolbar(
     navigationIcon: (@Composable () -> Unit)? = null,
     actionIcon: (@Composable () -> Unit)? = null,
 ) {
-    Row(
-        modifier = modifier
-            .padding(
-                top = with(LocalDensity.current) {
-                    WindowInsets.statusBarsIgnoringVisibility
-                        .getTop(this)
-                        .toDp()
-                }
+    Column(modifier = modifier) {
+        Row(
+            modifier = Modifier
+                .padding(
+                    top = with(LocalDensity.current) {
+                        WindowInsets.statusBarsIgnoringVisibility
+                            .getTop(this)
+                            .toDp()
+                    }
+                )
+                .fillMaxWidth()
+                .height(50.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier.size(20.dp)
+            ) {
+                navigationIcon?.invoke()
+            }
+            Spacer(modifier = Modifier.size(12.dp))
+            Text(
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Center,
+                text = title,
+                color = FarmemeTheme.textColor.primary,
+                style = FarmemeTheme.typography.body.xLarge.semibold,
             )
-            .fillMaxWidth()
-            .height(50.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Box(
-            modifier = Modifier
-                .padding(start = 20.dp)
-                .padding(vertical = 15.dp)
-                .size(20.dp)
-        ) {
-            if (navigationIcon != null) {
-                navigationIcon()
+            Spacer(modifier = Modifier.size(12.dp))
+            Box(
+                modifier = Modifier.size(20.dp)
+            ) {
+                actionIcon?.invoke()
             }
         }
-        Text(
-            modifier = Modifier.weight(1f),
-            textAlign = TextAlign.Center,
-            text = title,
-            color = FarmemeTheme.textColor.primary,
-            style = FarmemeTheme.typography.body.xLarge.semibold,
+        Divider(
+            modifier = Modifier.fillMaxWidth(),
+            color = FarmemeTheme.backgroundColor.assistive,
+            thickness = 1.dp,
         )
-        Box(
-            modifier = Modifier
-                .padding(end = 20.dp)
-                .padding(vertical = 15.dp)
-                .size(20.dp)
-        ) {
-            if (actionIcon != null) {
-                actionIcon()
-            }
-        }
     }
 }
 

--- a/core/designsystem/src/main/kotlin/team/ppac/designsystem/foundation/Icon.kt
+++ b/core/designsystem/src/main/kotlin/team/ppac/designsystem/foundation/Icon.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import team.ppac.designsystem.FarmemeTheme
 import team.ppac.designsystem.R
 
 object FarmemeIcon {
@@ -365,5 +366,15 @@ object FarmemeIcon {
         modifier = modifier,
         painter = painterResource(R.drawable.ic_caution_48),
         contentDescription = null,
+    )
+
+    @Composable
+    fun EmptyResult(
+        modifier: Modifier = Modifier,
+    ) = Icon(
+        modifier = modifier,
+        painter = painterResource(R.drawable.ic_empty_80),
+        contentDescription = null,
+        tint = Color.Unspecified
     )
 }

--- a/core/designsystem/src/main/res/drawable/ic_empty_80.xml
+++ b/core/designsystem/src/main/res/drawable/ic_empty_80.xml
@@ -1,0 +1,45 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="80dp"
+    android:height="80dp"
+    android:viewportWidth="80"
+    android:viewportHeight="80">
+  <path
+      android:pathData="M40,40m-38,0a38,38 0,1 1,76 0a38,38 0,1 1,-76 0"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#1E2227"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M30.049,50.049C35.512,50.049 39.935,43.814 39.935,36.117C39.935,28.421 35.506,22.185 30.049,22.185C24.593,22.185 20.164,28.421 20.164,36.117C20.164,43.814 24.593,50.049 30.049,50.049Z"
+      android:strokeWidth="2"
+      android:fillColor="#ffffff"
+      android:strokeColor="#1E2227"/>
+  <path
+      android:pathData="M34.855,28.069C33.572,26.429 31.875,25.434 30.005,25.434C26.693,25.434 23.91,28.574 23.062,32.849L34.855,28.069Z"
+      android:fillColor="#1E2227"/>
+  <path
+      android:pathData="M23.036,38.216C23.853,42.575 26.661,45.792 30.011,45.792C34,45.792 37.236,41.235 37.236,35.613C37.236,35.166 37.21,34.732 37.172,34.304L23.036,38.216Z"
+      android:fillColor="#1E2227"/>
+  <path
+      android:pathData="M46.279,50.049C51.742,50.049 56.164,43.814 56.164,36.117C56.164,28.421 51.735,22.185 46.279,22.185C40.822,22.185 36.393,28.421 36.393,36.117C36.393,43.814 40.822,50.049 46.279,50.049Z"
+      android:strokeWidth="2"
+      android:fillColor="#ffffff"
+      android:strokeColor="#1E2227"/>
+  <path
+      android:pathData="M50.139,28.063C48.863,26.429 47.172,25.44 45.315,25.44C42.022,25.44 39.246,28.567 38.397,32.824L50.139,28.063Z"
+      android:fillColor="#1E2227"/>
+  <path
+      android:pathData="M38.371,38.159C39.188,42.499 41.984,45.702 45.315,45.702C49.291,45.702 52.507,41.165 52.507,35.568C52.507,35.128 52.482,34.694 52.443,34.266L38.371,38.165V38.159Z"
+      android:fillColor="#1E2227"/>
+  <path
+      android:pathData="M49.848,57.386C48.551,58.525 46.866,58.712 44.266,57.187C42.472,55.792 36.891,54.396 31.907,57.586C25.487,61.695 19.424,52.33 30.273,48.501C42.77,44.09 49.82,51.456 50.376,52.011C51.333,52.968 51.972,55.521 49.848,57.386Z"
+      android:strokeWidth="2"
+      android:fillColor="#ffffff"
+      android:strokeColor="#1E2227"/>
+  <path
+      android:pathData="M46.162,53.784C43.731,51.838 36.7,49.105 28.018,53.741"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#1E2227"
+      android:strokeLineCap="round"/>
+</vector>

--- a/feature/search/src/main/java/team/ppac/search/detail/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/team/ppac/search/detail/SearchDetailScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -15,6 +14,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import team.ppac.designsystem.component.scaffold.FarmemeScaffold
 import team.ppac.designsystem.component.tabbar.TabBarHeight
 import team.ppac.designsystem.component.toolbar.FarmemeBackToolBar
+import team.ppac.search.detail.component.EmptyResultContent
 import team.ppac.search.detail.component.SearchDetailResultContent
 import team.ppac.search.detail.component.SearchDetailResultHeader
 import team.ppac.search.detail.mvi.SearchDetailUiState
@@ -49,6 +49,9 @@ internal fun SearchDetailScreen(
         Column(
             modifier = Modifier.padding(innerPadding)
         ) {
+            if (searchResults.itemCount == 0) {
+                EmptyResultContent()
+            }
             SearchDetailResultHeader(totalCount = searchResults.itemCount)
             SearchDetailResultContent(
                 searchResults = searchResults,

--- a/feature/search/src/main/java/team/ppac/search/detail/component/EmptyResultContent.kt
+++ b/feature/search/src/main/java/team/ppac/search/detail/component/EmptyResultContent.kt
@@ -1,0 +1,63 @@
+package team.ppac.search.detail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import team.ppac.designsystem.FarmemeTheme
+
+@Composable
+fun EmptyResultContent(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.size(160.dp))
+        Column(
+            modifier = Modifier.weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(80.dp)
+                    .background(Color.Red)
+            )
+            Spacer(modifier = Modifier.size(20.dp))
+            Text(
+                text = "밈이 없어요",
+                style = FarmemeTheme.typography.heading.small.bold.copy(
+                    color = FarmemeTheme.textColor.primary
+                )
+            )
+            Spacer(modifier = Modifier.size(9.dp))
+            Text(
+                text = "카페인 빨리 충전하고\n재밌는 밈 채워둘게요!",
+                style = FarmemeTheme.typography.body.large.medium.copy(
+                    color = FarmemeTheme.textColor.tertiary
+                )
+            )
+        }
+        Spacer(modifier = Modifier.size(160.dp))
+    }
+}
+
+@Preview
+@Composable
+private fun EmptyResultContentPreview() {
+    Box(modifier = Modifier.background(Color.White)) {
+        EmptyResultContent()
+    }
+}

--- a/feature/search/src/main/java/team/ppac/search/detail/component/EmptyResultContent.kt
+++ b/feature/search/src/main/java/team/ppac/search/detail/component/EmptyResultContent.kt
@@ -1,7 +1,6 @@
 package team.ppac.search.detail.component
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -15,26 +14,21 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import team.ppac.designsystem.FarmemeTheme
+import team.ppac.designsystem.foundation.FarmemeIcon
 
 @Composable
 fun EmptyResultContent(
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    Box(
         modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
+        contentAlignment = Alignment.Center
     ) {
-        Spacer(modifier = Modifier.size(160.dp))
         Column(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Box(
-                modifier = Modifier
-                    .size(80.dp)
-                    .background(Color.Red)
-            )
+            FarmemeIcon.EmptyResult()
             Spacer(modifier = Modifier.size(20.dp))
             Text(
                 text = "밈이 없어요",
@@ -50,7 +44,6 @@ fun EmptyResultContent(
                 )
             )
         }
-        Spacer(modifier = Modifier.size(160.dp))
     }
 }
 


### PR DESCRIPTION
### Issue
- close #108 
- close #136 

### 작업 내역 (Required)
- 기존 화면 구성 시 처리하지 않았던 디테일한 UI 요소들을 처리했습니다.
  - 검색 상세 / 데이터가 비어있을 때 EmptyScreen 표시
  - 검색 상세 / FarmemeMemeItem 이미지 로딩 Placeholder 표시
  - DesignSystem / 탑바 하단에 Divider Line 표시
  - 그 외 잔여 건들은 이전 PR에서 다 포함되어 해결 되었습니다.

### Review Point (Required)
- 딱히 볼 만한거 없을겁니당 ㅋㅋ

### 관련 링크
- none