### PR TITLE
[Feat] 화면 전환 효과 모두 없애기

### DIFF
--- a/app/src/main/java/team/ppac/navigation/FarmemeNavHost.kt
+++ b/app/src/main/java/team/ppac/navigation/FarmemeNavHost.kt
@@ -1,5 +1,7 @@
 package team.ppac.navigation
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -28,6 +30,8 @@ fun FarmemeNavHost(
         modifier = modifier,
         navController = navController,
         startDestination = startDestination,
+        enterTransition = { EnterTransition.None },
+        exitTransition = { ExitTransition.None },
     ) {
         recommendationScreen()
         searchScreen(

--- a/core/common/android/src/main/kotlin/team/ppac/common/android/extension/ActivityExtension.kt
+++ b/core/common/android/src/main/kotlin/team/ppac/common/android/extension/ActivityExtension.kt
@@ -6,5 +6,7 @@ import android.content.Intent
 inline fun <reified T : Activity> Activity.getIntent(
     intentBuilder: Intent.() -> Intent = { this },
 ): Intent {
-    return intentBuilder(Intent(this, T::class.java))
+    return intentBuilder(Intent(this, T::class.java).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+    })
 }

--- a/core/common/android/src/main/kotlin/team/ppac/common/android/extension/ContextExtension.kt
+++ b/core/common/android/src/main/kotlin/team/ppac/common/android/extension/ContextExtension.kt
@@ -7,5 +7,7 @@ import android.content.Intent
 inline fun <reified T : Activity> Context.getIntent(
     intentBuilder: Intent.() -> Intent = { this },
 ): Intent {
-    return intentBuilder(Intent(this, T::class.java))
+    return intentBuilder(Intent(this, T::class.java).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+    })
 }

--- a/core/common/android/src/main/kotlin/team/ppac/common/android/util/OnBackPressed.kt
+++ b/core/common/android/src/main/kotlin/team/ppac/common/android/util/OnBackPressed.kt
@@ -1,0 +1,13 @@
+package team.ppac.common.android.util
+
+import androidx.activity.ComponentActivity
+import androidx.activity.OnBackPressedCallback
+
+fun ComponentActivity.onBackPressed(action: () -> Unit) {
+    val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            action()
+        }
+    }
+    onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
+}

--- a/core/common/android/src/main/kotlin/team/ppac/common/android/util/TransitionAnimation.kt
+++ b/core/common/android/src/main/kotlin/team/ppac/common/android/util/TransitionAnimation.kt
@@ -1,0 +1,13 @@
+package team.ppac.common.android.util
+
+import android.app.Activity
+import android.os.Build
+
+fun Activity.noTransitionAnimation() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        overrideActivityTransition(Activity.OVERRIDE_TRANSITION_OPEN, 0, 0)
+        overrideActivityTransition(Activity.OVERRIDE_TRANSITION_CLOSE, 0, 0)
+    } else {
+        overridePendingTransition(0, 0)
+    }
+}

--- a/feature/detail/src/main/java/team/ppac/detail/DetailActivity.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailActivity.kt
@@ -5,6 +5,8 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.core.view.WindowCompat
 import dagger.hilt.android.AndroidEntryPoint
+import team.ppac.common.android.util.noTransitionAnimation
+import team.ppac.common.android.util.onBackPressed
 import team.ppac.designsystem.FarmemeTheme
 
 @AndroidEntryPoint
@@ -14,8 +16,16 @@ class DetailActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             FarmemeTheme {
-                DetailRoute(navigateToBack = { finish() })
+                DetailRoute(navigateToBack = {
+                    finish()
+                    noTransitionAnimation()
+                })
             }
+        }
+
+        onBackPressed {
+            finish()
+            noTransitionAnimation()
         }
     }
 }

--- a/feature/detail/src/main/java/team/ppac/detail/DetailActivity.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailActivity.kt
@@ -6,7 +6,6 @@ import androidx.activity.compose.setContent
 import androidx.core.view.WindowCompat
 import dagger.hilt.android.AndroidEntryPoint
 import team.ppac.common.android.util.noTransitionAnimation
-import team.ppac.common.android.util.onBackPressed
 import team.ppac.designsystem.FarmemeTheme
 
 @AndroidEntryPoint
@@ -16,16 +15,9 @@ class DetailActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             FarmemeTheme {
-                DetailRoute(navigateToBack = {
-                    finish()
-                    noTransitionAnimation()
-                })
+                DetailRoute(navigateToBack = { finish() })
             }
         }
-
-        onBackPressed {
-            finish()
-            noTransitionAnimation()
-        }
+        noTransitionAnimation()
     }
 }

--- a/feature/mypage/src/main/java/team/ppac/mypage/MyPageRoute.kt
+++ b/feature/mypage/src/main/java/team/ppac/mypage/MyPageRoute.kt
@@ -42,7 +42,7 @@ internal fun MyPageRoute(
             viewModel.intent(MyPageIntent.InitView)
         }
 
-        DisposableEffect(key1 = Unit) {
+        DisposableEffect(key1 = Unit) {// TODO(ze-zeh) : viewModel이 초기화 되지 않아서 기존 상태가 남아있는 문제 임시 해결
             onDispose {
                 viewModel.intent(MyPageIntent.DisposeView)
             }

--- a/feature/mypage/src/main/java/team/ppac/mypage/MyPageRoute.kt
+++ b/feature/mypage/src/main/java/team/ppac/mypage/MyPageRoute.kt
@@ -2,6 +2,7 @@ package team.ppac.mypage
 
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -39,6 +40,12 @@ internal fun MyPageRoute(
 
         LaunchedEffect(key1 = Unit) {
             viewModel.intent(MyPageIntent.InitView)
+        }
+
+        DisposableEffect(key1 = Unit) {
+            onDispose {
+                viewModel.intent(MyPageIntent.DisposeView)
+            }
         }
 
         MyPageScreen(

--- a/feature/mypage/src/main/java/team/ppac/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/team/ppac/mypage/MyPageViewModel.kt
@@ -56,13 +56,21 @@ class MyPageViewModel @Inject constructor(
             is MyPageIntent.ClickRecentMemeItem -> navigateToDetail(intent.memeId)
             is MyPageIntent.ClickSavedMemeItem -> navigateToDetail(intent.memeId)
             MyPageIntent.ClickSettingButton -> navigateToSetting()
-            MyPageIntent.InitView -> initialAction()
-            MyPageIntent.RefreshData -> refreshAction()
             is MyPageIntent.ClickRetryButton -> {
                 initialAction()
                 reduce {
                     copy(
                         isError = false,
+                    )
+                }
+            }
+
+            MyPageIntent.InitView -> initialAction()
+            MyPageIntent.RefreshData -> refreshAction()
+            MyPageIntent.DisposeView -> {
+                reduce {
+                    copy(
+                        isLoading = true,
                     )
                 }
             }

--- a/feature/mypage/src/main/java/team/ppac/mypage/mvi/MyPageIntent.kt
+++ b/feature/mypage/src/main/java/team/ppac/mypage/mvi/MyPageIntent.kt
@@ -6,7 +6,8 @@ sealed class MyPageIntent : UiIntent {
     data object ClickSettingButton : MyPageIntent()
     data class ClickRecentMemeItem(val memeId: String) : MyPageIntent()
     data class ClickSavedMemeItem(val memeId: String) : MyPageIntent()
+    data object ClickRetryButton : MyPageIntent()
     data object InitView : MyPageIntent()
     data object RefreshData : MyPageIntent()
-    data object ClickRetryButton : MyPageIntent()
+    data object DisposeView : MyPageIntent()
 }

--- a/feature/setting/src/main/java/team/ppac/setting/SettingActivity.kt
+++ b/feature/setting/src/main/java/team/ppac/setting/SettingActivity.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
+import team.ppac.common.android.util.noTransitionAnimation
+import team.ppac.common.android.util.onBackPressed
 import team.ppac.designsystem.FarmemeTheme
 
 @AndroidEntryPoint
@@ -24,9 +26,15 @@ class SettingActivity : ComponentActivity() {
                     navController = navController,
                     navigateToBack = {
                         finish()
+                        noTransitionAnimation()
                     },
                 )
             }
+        }
+
+        onBackPressed {
+            finish()
+            noTransitionAnimation()
         }
     }
 }

--- a/feature/setting/src/main/java/team/ppac/setting/SettingActivity.kt
+++ b/feature/setting/src/main/java/team/ppac/setting/SettingActivity.kt
@@ -9,7 +9,6 @@ import androidx.core.view.WindowCompat
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import team.ppac.common.android.util.noTransitionAnimation
-import team.ppac.common.android.util.onBackPressed
 import team.ppac.designsystem.FarmemeTheme
 
 @AndroidEntryPoint
@@ -24,17 +23,10 @@ class SettingActivity : ComponentActivity() {
                 SettingNavHost(
                     modifier = Modifier.fillMaxSize(),
                     navController = navController,
-                    navigateToBack = {
-                        finish()
-                        noTransitionAnimation()
-                    },
+                    navigateToBack = { finish() },
                 )
             }
         }
-
-        onBackPressed {
-            finish()
-            noTransitionAnimation()
-        }
+        noTransitionAnimation()
     }
 }

--- a/feature/setting/src/main/java/team/ppac/setting/SettingNavHost.kt
+++ b/feature/setting/src/main/java/team/ppac/setting/SettingNavHost.kt
@@ -1,5 +1,7 @@
 package team.ppac.setting
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
@@ -20,6 +22,8 @@ fun SettingNavHost(
         modifier = modifier,
         navController = navController,
         startDestination = startDestination,
+        enterTransition = { EnterTransition.None },
+        exitTransition = { ExitTransition.None }
     ) {
         settingScreen(
             navigateToPrivacyPolicy = { navController.navigateToPrivacyPolicy() },


### PR DESCRIPTION
### Issue
- close #123 

### 작업 내역 (Required)
- 화면 전환 효과 모두 없애기

### Review Point (Required)
- onBackPressed가 deprecated 됐다고 해서 대체하는 확장함수 추가해놨습니다
참고링크 : https://stickode.tistory.com/625
- 기존 intent 확장함수에 애니메이션을 제거하는 코드 추가했는데 괜찮은지 말해주세요~