### PR TITLE
검색 모아보기 관련 이슈 수정

### DIFF
--- a/core/domain/src/main/java/team/ppac/domain/model/MemeWithPagination.kt
+++ b/core/domain/src/main/java/team/ppac/domain/model/MemeWithPagination.kt
@@ -1,0 +1,9 @@
+package team.ppac.domain.model
+
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+
+data class MemeWithPagination(
+    val totalMemeCount: Int,
+    val memes: Flow<PagingData<Meme>>,
+)

--- a/core/domain/src/main/java/team/ppac/domain/repository/MemeRepository.kt
+++ b/core/domain/src/main/java/team/ppac/domain/repository/MemeRepository.kt
@@ -4,13 +4,14 @@ import androidx.paging.PagingData
 import kotlinx.coroutines.flow.Flow
 import team.ppac.domain.model.Meme
 import team.ppac.domain.model.MemeWatchType
+import team.ppac.domain.model.MemeWithPagination
 
 interface MemeRepository {
     suspend fun getMeme(memeId: String): Meme
     suspend fun getRecommendMemes(): List<Meme>
     suspend fun saveMeme(memeId: String): Boolean
     suspend fun deleteSavedMeme(memeId: String): Boolean
-    fun getSearchMemes(keyword: String): Flow<PagingData<Meme>>
+    suspend fun getSearchMemes(keyword: String): MemeWithPagination
     suspend fun reactMeme(memeId: String): Boolean
     suspend fun watchMeme(
         memeId: String,

--- a/core/domain/src/main/java/team/ppac/domain/usecase/GetSearchMemeUseCase.kt
+++ b/core/domain/src/main/java/team/ppac/domain/usecase/GetSearchMemeUseCase.kt
@@ -1,19 +1,17 @@
 package team.ppac.domain.usecase
 
-import androidx.paging.PagingData
-import kotlinx.coroutines.flow.Flow
-import team.ppac.domain.model.Meme
+import team.ppac.domain.model.MemeWithPagination
 import team.ppac.domain.repository.MemeRepository
 import javax.inject.Inject
 
 interface GetSearchMemeUseCase {
-    operator fun invoke(keyword: String): Flow<PagingData<Meme>>
+    suspend operator fun invoke(keyword: String): MemeWithPagination
 }
 
 internal class GetSearchMemeUseCaseImpl @Inject constructor(
     private val memeRepository: MemeRepository,
 ) : GetSearchMemeUseCase {
-    override fun invoke(keyword: String): Flow<PagingData<Meme>> {
+    override suspend fun invoke(keyword: String): MemeWithPagination {
         return memeRepository.getSearchMemes(keyword)
     }
 }

--- a/core/remote/src/main/kotlin/team/ppac/remote/datasource/MemeDataSource.kt
+++ b/core/remote/src/main/kotlin/team/ppac/remote/datasource/MemeDataSource.kt
@@ -1,6 +1,7 @@
 package team.ppac.remote.datasource
 
 import team.ppac.remote.model.response.meme.MemeResponse
+import team.ppac.remote.model.response.user.SavedMemesResponse
 
 interface MemeDataSource {
     suspend fun getMemeById(memeId: String): MemeResponse
@@ -11,7 +12,7 @@ interface MemeDataSource {
         keyword: String,
         page: Int,
         size: Int,
-    ): List<MemeResponse>
+    ): SavedMemesResponse
     suspend fun reactMeme(memeId: String): Boolean
     suspend fun watchMeme(
         memeId: String,

--- a/core/remote/src/main/kotlin/team/ppac/remote/datasource/impl/MemeDataSourceImpl.kt
+++ b/core/remote/src/main/kotlin/team/ppac/remote/datasource/impl/MemeDataSourceImpl.kt
@@ -3,6 +3,7 @@ package team.ppac.remote.datasource.impl
 import team.ppac.remote.api.MemeApi
 import team.ppac.remote.datasource.MemeDataSource
 import team.ppac.remote.model.response.meme.MemeResponse
+import team.ppac.remote.model.response.user.SavedMemesResponse
 import javax.inject.Inject
 
 internal class MemeDataSourceImpl @Inject constructor(
@@ -24,8 +25,8 @@ internal class MemeDataSourceImpl @Inject constructor(
         return memeApi.deleteSavedMeme(memeId)
     }
 
-    override suspend fun getSearchMemes(keyword: String, page: Int, size: Int): List<MemeResponse> {
-        return memeApi.getSearchMemes(keyword, page, size).memeList
+    override suspend fun getSearchMemes(keyword: String, page: Int, size: Int): SavedMemesResponse {
+        return memeApi.getSearchMemes(keyword, page, size)
     }
 
     override suspend fun reactMeme(memeId: String): Boolean {

--- a/feature/search/src/main/java/team/ppac/search/detail/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/team/ppac/search/detail/SearchDetailScreen.kt
@@ -83,15 +83,16 @@ internal fun SearchDetailScreen(
                         Column(
                             modifier = Modifier.padding(innerPadding)
                         ) {
-                            if (searchResults.itemCount == 0) {
+                            if (uiState.totalMemeCount == 0) {
                                 EmptyResultContent()
+                            } else {
+                                SearchDetailResultHeader(totalCount = uiState.totalMemeCount)
+                                SearchDetailResultContent(
+                                    searchResults = searchResults,
+                                    onMemeClick = onMemeClick,
+                                    onCopyClick = onCopyClick
+                                )
                             }
-                            SearchDetailResultHeader(totalCount = searchResults.itemCount)
-                            SearchDetailResultContent(
-                                searchResults = searchResults,
-                                onMemeClick = onMemeClick,
-                                onCopyClick = onCopyClick
-                            )
                         }
                     }
                 }

--- a/feature/search/src/main/java/team/ppac/search/detail/SearchDetailViewModel.kt
+++ b/feature/search/src/main/java/team/ppac/search/detail/SearchDetailViewModel.kt
@@ -83,21 +83,26 @@ class SearchDetailViewModel @Inject constructor(
     private fun getSearchResults(memeCategory: String) = launch {
         updateLoadingState(true)
         delay(300L)
-        val searchResults = getSearchMemeUseCase(memeCategory)
+
+        val paginationResults = getSearchMemeUseCase(memeCategory)
+        val totalMemeCount = paginationResults.totalMemeCount
+        val searchResults = paginationResults.memes
             .map { pagingData ->
                 pagingData.map { it.toSearchResultUiModel() }
             }.cachedIn(viewModelScope)
 
         updateLoadingState(false)
-        updateSearchResults(memeCategory, searchResults)
+        updateSearchResults(totalMemeCount, memeCategory, searchResults)
     }
 
     private fun updateSearchResults(
+        totalMemeCount: Int,
         memeCategory: String,
         searchResults: Flow<PagingData<SearchResultUiModel>>,
     ) {
         reduce {
             copy(
+                totalMemeCount = totalMemeCount,
                 memeCategory = memeCategory,
                 searchResults = searchResults
             )

--- a/feature/search/src/main/java/team/ppac/search/detail/mvi/SearchDetailUiState.kt
+++ b/feature/search/src/main/java/team/ppac/search/detail/mvi/SearchDetailUiState.kt
@@ -9,6 +9,7 @@ import team.ppac.search.detail.model.SearchResultUiModel
 data class SearchDetailUiState(
     val isLoading: Boolean,
     val isError: Boolean,
+    val totalMemeCount: Int,
     val memeCategory: String,
     val searchResults: Flow<PagingData<SearchResultUiModel>>,
 ) : UiState {
@@ -17,6 +18,7 @@ data class SearchDetailUiState(
         val INITIAL_STATE = SearchDetailUiState(
             isLoading = true,
             isError = false,
+            totalMemeCount = 0,
             memeCategory = "",
             searchResults = flowOf(PagingData.empty())
         )


### PR DESCRIPTION
### Issue
- #193 
- close #195 

### 작업 내역 (Required)
- MemeWithPagination 도메인 모델 추가
- 페이징 Repository 로직 수정
- 검색 모아보기 진입 시 EmptyScreen 일시적으로 노출 후 전체 컨텐츠 노출되는 이슈 수정

### Review Point (Required)
- 이게 PaginaSource에서 처리를 해서 내려보내주려고 했는데 LoadResult.Page의 data로 들어가는 타입이 `List<T>`더라구여 ;; MemeWithPagination에 `Flow<PagingData<T>>`가 포함되기 떄문에 data로 내려보내줄수가 없었습니다 ㅠㅠ 일단 동작은 되게끔 구현은 해놨는데 여전히 전체 갯수 로드를 위해 API를 한번 더 call하는 문제는 있습니다
``` kotlin
public data class Page<Key : Any, Value : Any> constructor(
    /**
     * Loaded data
     */
    val data: List<Value>,
    
    val prevKey: Key ?,
    
    val nextKey: Key ?,
    
    @IntRange(from = COUNT_UNDEFINED.toLong()) 
    val itemsBefore: Int = COUNT_UNDEFINED,
    
    @IntRange(from = COUNT_UNDEFINED.toLong()) 
    val itemsAfter: Int = COUNT_UNDEFINED
) : LoadResult<Key, Value>(), Iterable<Value> { .. }

// MemeRepositoryImpl.kt
override suspend fun getSearchMemes(keyword: String): MemeWithPagination {
   val totalMemeCount = memeDataSource.getSearchMemes(
       keyword = keyword,
       page = 1,
       size = ITEMS_PER_PAGE
   ).pagination.total

    return MemeWithPagination(
        totalMemeCount = totalMemeCount,
        memes = createPager { page ->
           memeDataSource.getSearchMemes(
                keyword = keyword,
                page = page,
                size = ITEMS_PER_PAGE,
           ).memeList.map { it.toMeme() }
        }.flow
    )
}
```

### Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://github.com/user-attachments/assets/585f7582-4c04-4dcf-9e58-2e11d8583a2a" width="300" />

### 관련 링크
- none