### PR TITLE
[QA] 상세페이지 UI가이드와 다름 

### DIFF
--- a/core/designsystem/src/main/kotlin/team/ppac/designsystem/component/scaffold/Scaffold.kt
+++ b/core/designsystem/src/main/kotlin/team/ppac/designsystem/component/scaffold/Scaffold.kt
@@ -1,6 +1,7 @@
 package team.ppac.designsystem.component.scaffold
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -22,6 +23,7 @@ fun FarmemeScaffold(
     modifier: Modifier = Modifier,
     isIncludeHorizontalPadding: Boolean = true,
     backgroundColorType: BackgroundColorType = defaultColorType(),
+    backgroundImage: @Composable () -> Unit = {},
     topBar: @Composable () -> Unit = {},
     bottomBar: @Composable () -> Unit = {},
     content: @Composable (PaddingValues) -> Unit,
@@ -35,24 +37,29 @@ fun FarmemeScaffold(
             Modifier.background(color = backgroundColorType.color)
         }
     }
+    Box(modifier = Modifier.fillMaxSize()) {
+        backgroundImage()
+        Column(
+            modifier = modifier.then(backgroundModifier),
+        ) {
+            Box {
+                backgroundImage()
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    backgroundColor = Color.Transparent,
+                    topBar = topBar,
+                    bottomBar = bottomBar,
+                ) { paddingValues ->
+                    val innerPadding = PaddingValues(
+                        top = paddingValues.calculateTopPadding(),
+                        start = if (isIncludeHorizontalPadding) ContentMargin else 0.dp,
+                        end = if (isIncludeHorizontalPadding) ContentMargin else 0.dp,
+                        bottom = paddingValues.calculateBottomPadding()
+                    )
 
-    Column(
-        modifier = modifier.then(backgroundModifier),
-    ) {
-        Scaffold(
-            modifier = Modifier.fillMaxSize(),
-            backgroundColor = Color.Transparent,
-            topBar = topBar,
-            bottomBar = bottomBar,
-        ) { paddingValues ->
-            val innerPadding = PaddingValues(
-                top = paddingValues.calculateTopPadding(),
-                start = if (isIncludeHorizontalPadding) ContentMargin else 0.dp,
-                end = if (isIncludeHorizontalPadding) ContentMargin else 0.dp,
-                bottom = paddingValues.calculateBottomPadding()
-            )
-
-            content(innerPadding)
+                    content(innerPadding)
+                }
+            }
         }
     }
 }

--- a/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
@@ -75,6 +75,7 @@ fun PreviewDetailScreen() {
                 sourceDescription = "출처에 대한 내용이 들어갑니다.",
                 isSavedMeme = false,
                 reactionCount = 0,
+                isReaction = false,
             ),
             isError = false,
             isLoading = false,

--- a/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
@@ -1,6 +1,8 @@
 package team.ppac.detail
 
 import android.graphics.Bitmap
+import android.os.Build
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -8,8 +10,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlurEffect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import coil.compose.AsyncImage
+import coil.request.CachePolicy
+import coil.request.ImageRequest
 import kotlinx.collections.immutable.persistentListOf
+import team.ppac.designsystem.FarmemeTheme
 import team.ppac.designsystem.component.scaffold.FarmemeScaffold
 import team.ppac.designsystem.component.toolbar.FarmemeBackToolBar
 import team.ppac.detail.component.DetailBottomBar
@@ -34,6 +44,38 @@ internal fun DetailScreen(
             FarmemeBackToolBar(
                 title = "밈 자세히 보기",
                 onClickBackIcon = onClickBackButton,
+            )
+        },
+        backgroundImage = {
+            AsyncImage(
+                model = ImageRequest
+                    .Builder(LocalContext.current)
+                    .diskCachePolicy(CachePolicy.ENABLED)
+                    .memoryCachePolicy(CachePolicy.ENABLED)
+                    .data(uiState.detailMemeUiModel.imageUrl)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        alpha = 0.4f
+                    }
+                    .background(
+                        color = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                            FarmemeTheme.backgroundColor.white.copy(alpha = 0.3f)
+                        } else {
+                            FarmemeTheme.backgroundColor.white.copy(alpha = 0.4f)
+                        }
+                    )
+                    .graphicsLayer {
+                        renderEffect =
+                            BlurEffect(
+                                50f,
+                                50f,
+                            )
+                    }
             )
         },
         bottomBar = {
@@ -71,7 +113,7 @@ fun PreviewDetailScreen() {
             detailMemeUiModel = DetailMemeUiModel(
                 imageUrl = "",
                 name = "나는 공부를 찢어",
-                hashTags = persistentListOf("#공부", "#학생", "#시험기간", "#힘듦", "#피곤"),
+                hashTags = persistentListOf("공부", "학생", "시험기간", "힘듦", "피곤"),
                 sourceDescription = "출처에 대한 내용이 들어갑니다.",
                 isSavedMeme = false,
                 reactionCount = 0,

--- a/feature/detail/src/main/java/team/ppac/detail/DetailViewModel.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailViewModel.kt
@@ -141,7 +141,8 @@ class DetailViewModel @Inject constructor(
         reduce {
             copy(
                 detailMemeUiModel = detailMemeUiModel.copy(
-                    reactionCount = detailMemeUiModel.reactionCount + 1
+                    reactionCount = detailMemeUiModel.reactionCount + 1,
+                    isReaction = true,
                 )
             )
         }
@@ -151,7 +152,8 @@ class DetailViewModel @Inject constructor(
             reduce {
                 copy(
                     detailMemeUiModel = detailMemeUiModel.copy(
-                        reactionCount = detailMemeUiModel.reactionCount - 1
+                        reactionCount = detailMemeUiModel.reactionCount - 1,
+                        isReaction = false
                     )
                 )
             }

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailBottomBar.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailBottomBar.kt
@@ -103,10 +103,16 @@ internal fun DetailBottomBar(
                     }
                 },
             ) {
-                FarmemeIcon.BookmarkLine(
-                    modifier = Modifier.size(20.dp),
-                    tint = animatedFarmemeButtonColor,
-                )
+                if(isSaved){
+                    FarmemeIcon.BookmarkFilled(
+                        modifier = Modifier.size(20.dp),
+                    )
+                }else{
+                    FarmemeIcon.BookmarkLine(
+                        modifier = Modifier.size(20.dp),
+                        tint = animatedFarmemeButtonColor,
+                    )
+                }
             }
         }
     }

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -99,6 +99,7 @@ internal fun DetailContent(
                         height = 46.dp
                     ),
                     reactionCount = uiModel.reactionCount,
+                    isReaction = uiModel.isReaction,
                     onClickFunnyButton = onClickFunnyButton,
                     onReactionButtonPositioned = onReactionButtonPositioned
                 )
@@ -231,6 +232,7 @@ internal fun DetailTags(
 fun DetailFunnyButton(
     modifier: Modifier = Modifier,
     reactionCount: Int,
+    isReaction: Boolean,
     onClickFunnyButton: () -> Unit,
     onReactionButtonPositioned: (Offset) -> Unit,
 ) {
@@ -275,19 +277,32 @@ fun DetailFunnyButton(
             exit = fadeOut(),
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                LottieAnimation(
-                    modifier = Modifier.size(
-                        height = 22.dp,
-                        width = 44.dp,
-                    ),
-                    composition = lottieComposition,
-                    progress = { lottieAnimatable.progress },
-                )
+                if (isReaction) {
+                    LottieAnimation(
+                        modifier = Modifier.size(
+                            height = 22.dp,
+                            width = 44.dp,
+                        ),
+                        composition = lottieComposition,
+                        progress = { lottieAnimatable.progress },
+                    )
+                } else {
+                    FarmemeIcon.KKHorizon(
+                        modifier = Modifier.size(
+                            height = 22.dp,
+                            width = 44.dp
+                        )
+                    )
+                }
                 Spacer(modifier = Modifier.width(6.dp))
                 Text(
                     text = "+$reactionCount",
                     style = FarmemeTheme.typography.highlight.basic,
-                    color = FarmemeTheme.textColor.brand
+                    color = if (isReaction) {
+                        FarmemeTheme.textColor.brand
+                    } else {
+                        FarmemeTheme.textColor.primary
+                    }
                 )
             }
         }

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -71,7 +71,9 @@ internal fun DetailContent(
                 width = 2.dp,
                 color = FarmemeTheme.borderColor.primary,
                 shape = FarmemeRadius.Radius20.shape,
-            ),
+            )
+            .clip(FarmemeRadius.Radius20.shape)
+            .background(FarmemeTheme.backgroundColor.white),
     ) {
         Column(
             modifier = Modifier.padding(10.dp),

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -75,29 +75,34 @@ internal fun DetailContent(
     ) {
         Column(
             modifier = Modifier.padding(10.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             DetailImage(
                 imageUrl = uiModel.imageUrl,
                 isLoading = isLoading,
                 saveBitmap = saveBitmap,
             )
-            DetailHashTags(
-                name = uiModel.name,
-                sourceDescription = uiModel.sourceDescription,
-                hashTags = uiModel.hashTags,
-                isLoading = isLoading
-            )
-            DetailFunnyButton(
-                modifier = Modifier.mapTextSkeletonModifierIfNeed(
-                    isLoading = isLoading,
-                    height = 46.dp
-                ),
-                reactionCount = uiModel.reactionCount,
-                onClickFunnyButton = onClickFunnyButton,
-                onReactionButtonPositioned = onReactionButtonPositioned
-            )
-            Spacer(modifier = Modifier.height(10.dp))
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 10.dp)
+                    .padding(top = 20.dp, bottom = 10.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                DetailHashTags(
+                    name = uiModel.name,
+                    sourceDescription = uiModel.sourceDescription,
+                    hashTags = uiModel.hashTags,
+                    isLoading = isLoading
+                )
+                DetailFunnyButton(
+                    modifier = Modifier.mapTextSkeletonModifierIfNeed(
+                        isLoading = isLoading,
+                        height = 46.dp
+                    ),
+                    reactionCount = uiModel.reactionCount,
+                    onClickFunnyButton = onClickFunnyButton,
+                    onReactionButtonPositioned = onReactionButtonPositioned
+                )
+            }
         }
     }
 }
@@ -181,7 +186,6 @@ internal fun DetailHashTags(
     hashTags: ImmutableList<String>,
     isLoading: Boolean,
 ) {
-    Spacer(modifier = Modifier.height(25.dp))
     Text(
         modifier = Modifier.mapTextSkeletonModifierIfNeed(isLoading = isLoading, height = 30.dp),
         text = name.truncateDisplayedString(16),
@@ -234,7 +238,7 @@ fun DetailFunnyButton(
     val coroutineScope = rememberCoroutineScope()
     val lottieAnimatable = rememberLottieAnimatable()
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .height(46.dp)
             .clip(FarmemeRadius.Radius10.shape)

--- a/feature/detail/src/main/java/team/ppac/detail/mapper/DetailUiModelMapper.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/mapper/DetailUiModelMapper.kt
@@ -11,4 +11,5 @@ internal fun Meme.toDetailMemeUiModel(): DetailMemeUiModel = DetailMemeUiModel(
     sourceDescription = "출처 : ".plus(source),
     isSavedMeme = isSaved,
     reactionCount = reactionCount,
+    isReaction = isReaction,
 )

--- a/feature/detail/src/main/java/team/ppac/detail/model/DetailMemeUiModel.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/model/DetailMemeUiModel.kt
@@ -9,4 +9,5 @@ data class DetailMemeUiModel(
     val sourceDescription: String,
     val isSavedMeme: Boolean,
     val reactionCount: Int,
+    val isReaction: Boolean,
 )

--- a/feature/detail/src/main/java/team/ppac/detail/mvi/DetailUiState.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/mvi/DetailUiState.kt
@@ -21,6 +21,7 @@ data class DetailUiState(
                 sourceDescription = "",
                 isSavedMeme = false,
                 reactionCount = -1,
+                isReaction = false,
             ),
             isError = false,
             isLoading = false,


### PR DESCRIPTION
### Issue
- close #183

### 작업 내역 (Required)
- https://www.notion.so/UI-886926056ef44506a7f9d9e775514c83 

- 이미지 좌우 여백 10.dp 고정 
- ㅋㅋㅋ 버튼  좌우 하단 간격 20dp로 수정
- 저장됨밈인 경우 파밈 아이콘 컬러 변경 
- 내가 리액션한 경우에만 brand 컬러로 변경되도록 수정
- 밈 이미지 소스에 블러 적용해서 배경화면으로 사용하기

- text font 크기 관련된 이슈는 제외했습니다. 
 
### Review Point (Required)


### Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://github.com/user-attachments/assets/39c6bd1f-9194-4edf-ad8e-e3ea145c3fc2" width="300" />

### 관련 링크
-