### PR TITLE
[QA] 추천 탭 카운팅이 실시간 변경되지 않는 문제

### DIFF
--- a/feature/recommendation/src/main/java/team/ppac/recommendation/RecommendationViewModel.kt
+++ b/feature/recommendation/src/main/java/team/ppac/recommendation/RecommendationViewModel.kt
@@ -147,7 +147,7 @@ class RecommendationViewModel @Inject constructor(
                     isLoading = false,
                     thisWeekMemes = thisWeekMemes.toImmutableList(),
                     seenMemeCount = user.memeRecommendWatchCount ?: 1,
-                    currentPage = user.memeRecommendWatchCount ?: 1,
+                    currentPage = user.memeRecommendWatchCount?.minus(1) ?: 0,
                     level = user.levelCount,
                 )
             }


### PR DESCRIPTION
### Issue
- https://www.notion.so/0e7b140601ec477483c8f2706e956155?pvs=4

### 작업 내역 (Required)
- API에서 가져온 현재까지 본 밈 개수와 현재 페이지 싱크가 맞지 않았음
as - is : 현재까지 본 밈의 개수 = 현재 페이지
to - be : 현재까지 본 밈 개수 - 1 = 현재 페이지