### PR TITLE
[Qa] 디테일 2차 QA수정 

### DIFF
--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -165,20 +165,6 @@ private fun DetailImage(
             onSuccess = { saveBitmap(it.result.drawable.toBitmap()) }
         )
         FarmemeImageDim()
-        if (!isLoading) {
-            Box(
-                modifier = Modifier
-                    .matchParentSize()
-                    .graphicsLayer(alpha = 0.80f)
-                    .background(
-                        brush = Brush.verticalGradient(
-                            colors = listOf(Color.Transparent, FarmemeTheme.iconColor.secondary),
-                            startY = 320f,
-                            endY = 1000f
-                        )
-                    )
-            )
-        }
     }
 }
 

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -23,9 +23,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -209,16 +206,12 @@ internal fun DetailTags(
     modifier: Modifier,
     hashTags: List<String>,
 ) {
-    Row(modifier = modifier) {
-        hashTags.forEach { hashTag ->
-            Text(
-                text = "#$hashTag",
-                color = FarmemeTheme.textColor.tertiary,
-                style = FarmemeTheme.typography.body.large.medium,
-            )
-            Spacer(modifier = Modifier.width(6.dp))
-        }
-    }
+    Text(
+        modifier = modifier,
+        text = hashTags.joinToString(" ") { "#$it" },
+        color = FarmemeTheme.textColor.tertiary,
+        style = FarmemeTheme.typography.body.large.medium,
+    )
 }
 
 @Composable


### PR DESCRIPTION
### Issue
- https://www.notion.so/Quality-Assurance-Board-037419ad68dd4b068e82b8cf6217bcae?p=886926056ef44506a7f9d9e775514c83&pm=s

@혜진 주 전체적으로 수정해줘서 너모 고마워!
한 가지 내가 빼먹은 게 있는 것 같아서 남기자면, 이미지 부분에 그라데이션 dim 같은 게 씌워져있는 것 같은데 그거 제거해줄 수 있어? 채영이가 만든 가이드는 dim이 적용될 때가 명시되어 있는데 케이스 상관없이 디폴트 적용처럼 보여서!

+) 궁금한 게, 모든 밈이 출처가 안 보이는데 QA 서버에 있는 데이터가 다 출처가 없어서 그런건가..? 아니면 저 영역이 아예 사라졌어.?

@혜진 주 백오피스에 출처를 입력을 안 했던 거였다. 출처있는 버전 찾았어! 근데, 해시태그 영역이 왼쪽으로 쏠린 건지는 모르겠는데 타이틀이랑 해시태그랑 출처가 중앙 정렬이 아닌 것 같오!

### 작업 내역 (Required)
- 중앙 정렬 안된것 처럼 보이는게 해시태그 마지막에" "가 있어서 삭제함
- 그라데이션은 화면사이즈가 극단적으로 작을때만 적용하는거여서 삭제함
todo
- 화면해상도 대응 코드 짤때 그라데이션 추가예정

### Review Point (Required)
- none

### Screenshot

Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/11d302ea-f0a7-40a7-8568-c9b4e1c531e3" width="300" />
| <img src="https://github.com/user-attachments/assets/26471042-7d8d-4419-952c-2991f9c9a4b3" width="300" />

### 관련 링크
-