### PR TITLE
[FIX] 스플래시에서 에러 발생 시 다이얼로그 처리

### DIFF
--- a/feature/splash/build.gradle.kts
+++ b/feature/splash/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(project(":core:designsystem"))
     implementation(project(":core:navigator"))
+    implementation(project(":core:error-handling"))
 
     implementation(platform(libs.compose.bom))
     implementation(libs.bundles.compose)

--- a/feature/splash/src/main/java/team/ppac/splash/NetworkErrorDialog.kt
+++ b/feature/splash/src/main/java/team/ppac/splash/NetworkErrorDialog.kt
@@ -1,0 +1,67 @@
+package team.ppac.splash
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import team.ppac.designsystem.FarmemeTheme
+import team.ppac.designsystem.foundation.FarmemeRadius
+import team.ppac.designsystem.util.extension.noRippleClickable
+
+@Composable
+fun NetworkErrorDialog(
+    modifier: Modifier = Modifier,
+    onConfirmClick: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+    ) {
+        Column(
+            modifier = modifier
+                .clip(FarmemeRadius.Radius20.shape)
+                .fillMaxWidth()
+                .background(FarmemeTheme.backgroundColor.white)
+                .padding(
+                    horizontal = 30.dp,
+                    vertical = 20.dp
+                )
+        ) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = "네트워크 연결이 불안정해요",
+                style = FarmemeTheme.typography.heading.medium.semibold.copy(
+                    color = FarmemeTheme.textColor.primary
+                ),
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = "잠시 후 다시 시도해주세요",
+                style = FarmemeTheme.typography.body.large.medium.copy(
+                    color = FarmemeTheme.textColor.secondary
+                ),
+            )
+            Spacer(modifier = Modifier.size(14.dp))
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .noRippleClickable(onClick = onConfirmClick),
+                text = "확인",
+                style = FarmemeTheme.typography.heading.small.bold.copy(
+                    color = FarmemeTheme.textColor.brand
+                ),
+                textAlign = TextAlign.End
+            )
+        }
+    }
+}

--- a/feature/splash/src/main/java/team/ppac/splash/SplashActivity.kt
+++ b/feature/splash/src/main/java/team/ppac/splash/SplashActivity.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.Text
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -20,6 +22,7 @@ import androidx.core.view.WindowCompat
 import dagger.hilt.android.AndroidEntryPoint
 import team.ppac.designsystem.FarmemeTheme
 import team.ppac.navigator.MainNavigator
+import team.ppac.splash.mvi.SplashIntent
 import team.ppac.splash.mvi.SplashSideEffect
 import javax.inject.Inject
 
@@ -47,6 +50,7 @@ class SplashActivity : ComponentActivity() {
                 }
             }
 
+            val state by viewModel.state.collectAsState()
             Column(
                 modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -61,6 +65,16 @@ class SplashActivity : ComponentActivity() {
                     text = "내가 찾던 밈을 파밍하다",
                     style = FarmemeTheme.typography.body.large.medium,
                     color = FarmemeTheme.textColor.primary,
+                )
+            }
+            if (state.isNetworkError) {
+                NetworkErrorDialog(
+                    onConfirmClick = {
+                        viewModel.intent(SplashIntent.ClickDialogConfirm)
+                    },
+                    onDismiss = {
+                        viewModel.intent(SplashIntent.ClickDialogConfirm)
+                    }
                 )
             }
         }

--- a/feature/splash/src/main/java/team/ppac/splash/SplashViewModel.kt
+++ b/feature/splash/src/main/java/team/ppac/splash/SplashViewModel.kt
@@ -1,13 +1,13 @@
 package team.ppac.splash
 
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import team.ppac.common.android.base.BaseViewModel
 import team.ppac.domain.usecase.CreateUserUseCase
+import team.ppac.errorhandling.FarmemeNetworkException
 import team.ppac.splash.mvi.SplashIntent
 import team.ppac.splash.mvi.SplashSideEffect
 import team.ppac.splash.mvi.SplashState
@@ -20,7 +20,7 @@ class SplashViewModel @Inject constructor(
 ) : BaseViewModel<SplashState, SplashSideEffect, SplashIntent>(savedStateHandle) {
 
     init {
-        viewModelScope.launch {
+        launch {
             launch {
                 userCreateUseCase()
             }
@@ -35,12 +35,24 @@ class SplashViewModel @Inject constructor(
     }
 
     override fun createInitialState(savedStateHandle: SavedStateHandle): SplashState {
-        return SplashState
+        return SplashState()
     }
 
     override fun handleClientException(throwable: Throwable) {
-
+        if (throwable is FarmemeNetworkException) {
+            reduce {
+                copy(isNetworkError = true)
+            }
+        }
     }
 
-    override suspend fun handleIntent(intent: SplashIntent) {}
+    override suspend fun handleIntent(intent: SplashIntent) {
+        when (intent) {
+            SplashIntent.ClickDialogConfirm -> {
+                reduce {
+                    copy(isNetworkError = false)
+                }
+            }
+        }
+    }
 }

--- a/feature/splash/src/main/java/team/ppac/splash/mvi/SplashIntent.kt
+++ b/feature/splash/src/main/java/team/ppac/splash/mvi/SplashIntent.kt
@@ -2,4 +2,6 @@ package team.ppac.splash.mvi
 
 import team.ppac.common.android.base.UiIntent
 
-object SplashIntent : UiIntent
+sealed interface SplashIntent : UiIntent {
+    object ClickDialogConfirm : SplashIntent
+}

--- a/feature/splash/src/main/java/team/ppac/splash/mvi/SplashState.kt
+++ b/feature/splash/src/main/java/team/ppac/splash/mvi/SplashState.kt
@@ -2,4 +2,6 @@ package team.ppac.splash.mvi
 
 import team.ppac.common.android.base.UiState
 
-object SplashState : UiState
+data class SplashState(
+    val isNetworkError: Boolean = false,
+) : UiState


### PR DESCRIPTION
### 작업 내역 (Required)
- Splash Viewmodel에서 launch 메서드를 사용하지 않아 에러를 처리하지 못해서, launch 쓰도록 변경