### PR TITLE
[QA] 디테일 스크린 해상도 대응

### DIFF
--- a/feature/detail/src/main/java/team/ppac/detail/DetailRoute.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailRoute.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -36,6 +37,7 @@ import team.ppac.common.android.util.shareOneLink
 import team.ppac.designsystem.R
 import team.ppac.detail.mvi.DetailIntent
 import team.ppac.detail.mvi.DetailSideEffect
+import team.ppac.detail.util.DetailScreenSize
 import kotlin.math.roundToInt
 
 @Composable
@@ -46,7 +48,10 @@ internal fun DetailRoute(
     navigateToBack: () -> Unit,
 ) {
     val context = LocalContext.current
+    val configuration = LocalConfiguration.current
 
+    val currentDetailScreenSize =
+        DetailScreenSize.from(configuration.screenWidthDp.dp, configuration.screenHeightDp.dp)
     val lottieComposition by rememberLottieComposition(
         LottieCompositionSpec.RawRes(R.raw.lol_rising_effect)
     )
@@ -59,7 +64,6 @@ internal fun DetailRoute(
     val saveBitmap: (Bitmap) -> Unit = {
         bitmap = it
     }
-
     BaseComposable(viewModel = viewModel) { uiState ->
         ComposableLifecycle { _, event ->
             when (event) {
@@ -183,7 +187,8 @@ internal fun DetailRoute(
                     },
                     onClickButtonButtons = viewModel::intent,
                     saveBitmap = saveBitmap,
-                    onHashTagsClick = { viewModel.intent(DetailIntent.ClickHashtags) }
+                    onHashTagsClick = { viewModel.intent(DetailIntent.ClickHashtags) },
+                    currentDetailScreenSize = currentDetailScreenSize,
                 )
                 LottieAnimation(
                     modifier = Modifier

--- a/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
@@ -3,18 +3,23 @@ package team.ppac.detail
 import android.graphics.Bitmap
 import android.os.Build
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlurEffect
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.CachePolicy
 import coil.request.ImageRequest
@@ -22,6 +27,7 @@ import kotlinx.collections.immutable.persistentListOf
 import team.ppac.designsystem.FarmemeTheme
 import team.ppac.designsystem.component.scaffold.FarmemeScaffold
 import team.ppac.designsystem.component.toolbar.FarmemeBackToolBar
+import team.ppac.designsystem.foundation.FarmemeRadius
 import team.ppac.detail.component.DetailBottomBar
 import team.ppac.detail.component.DetailContent
 import team.ppac.detail.model.DetailMemeUiModel
@@ -39,6 +45,10 @@ internal fun DetailScreen(
     saveBitmap: (bitmap: Bitmap) -> Unit,
     onHashTagsClick: () -> Unit,
 ) {
+    val configuration = LocalConfiguration.current
+    val screenWidthPx = configuration.screenWidthDp.dp
+    val screenHeightPx = configuration.screenHeightDp.dp
+
     FarmemeScaffold(
         modifier = modifier,
         topBar = {
@@ -94,14 +104,45 @@ internal fun DetailScreen(
                 .fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
-            DetailContent(
-                uiModel = uiState.detailMemeUiModel,
-                isLoading = uiState.isLoading,
-                saveBitmap = saveBitmap,
-                onClickFunnyButton = onClickFunnyButton,
-                onReactionButtonPositioned = onReactionButtonPosition,
-                onHashTagsClick = onHashTagsClick
-            )
+            Box(
+                modifier = modifier
+                    .border(
+                        width = 2.dp,
+                        color = FarmemeTheme.borderColor.primary,
+                        shape = FarmemeRadius.Radius20.shape,
+                    )
+                    .clip(FarmemeRadius.Radius20.shape)
+                    .background(FarmemeTheme.backgroundColor.white),
+            ) {
+                if (screenHeightPx < 640.dp) {
+                    Box(
+                        modifier = Modifier.padding(10.dp),
+                        contentAlignment = Alignment.BottomCenter
+                    ) {
+                        DetailContent(
+                            uiModel = uiState.detailMemeUiModel,
+                            isLoading = uiState.isLoading,
+                            saveBitmap = saveBitmap,
+                            onClickFunnyButton = onClickFunnyButton,
+                            onReactionButtonPositioned = onReactionButtonPosition,
+                            onHashTagsClick = onHashTagsClick,
+                        )
+                    }
+                } else {
+                    Column(
+                        modifier = Modifier.padding(10.dp),
+                    ) {
+                        DetailContent(
+                            uiModel = uiState.detailMemeUiModel,
+                            isLoading = uiState.isLoading,
+                            saveBitmap = saveBitmap,
+                            onClickFunnyButton = onClickFunnyButton,
+                            onReactionButtonPositioned = onReactionButtonPosition,
+                            onHashTagsClick = onHashTagsClick
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
@@ -147,7 +147,7 @@ internal fun DetailScreen(
 
 @Preview
 @Composable
-fun PreviewDetailScreen() {
+private fun PreviewDetailScreen() {
     DetailScreen(
         uiState = PREVIEW_STATE,
         onClickFunnyButton = {},

--- a/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlurEffect
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -44,10 +43,8 @@ internal fun DetailScreen(
     onClickButtonButtons: (DetailIntent.ClickBottomButton) -> Unit,
     saveBitmap: (bitmap: Bitmap) -> Unit,
     onHashTagsClick: () -> Unit,
+    currentDetailScreenSize: DetailScreenSize,
 ) {
-    val configuration = LocalConfiguration.current
-    val currentDetailScreenSize =
-        DetailScreenSize.from(configuration.screenWidthDp.dp, configuration.screenHeightDp.dp)
     FarmemeScaffold(
         modifier = modifier,
         topBar = {
@@ -158,6 +155,7 @@ fun PreviewDetailScreen() {
         onClickBackButton = {},
         onClickButtonButtons = {},
         saveBitmap = {},
-        onHashTagsClick = {}
+        onHashTagsClick = {},
+        currentDetailScreenSize = DetailScreenSize.MEDIUM
     )
 }

--- a/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
@@ -33,6 +33,7 @@ import team.ppac.detail.component.DetailContent
 import team.ppac.detail.model.DetailMemeUiModel
 import team.ppac.detail.mvi.DetailIntent
 import team.ppac.detail.mvi.DetailUiState
+import team.ppac.detail.util.DetailScreenSize
 
 @Composable
 internal fun DetailScreen(
@@ -46,9 +47,8 @@ internal fun DetailScreen(
     onHashTagsClick: () -> Unit,
 ) {
     val configuration = LocalConfiguration.current
-    val screenWidthPx = configuration.screenWidthDp.dp
-    val screenHeightPx = configuration.screenHeightDp.dp
-
+    val currentDetailScreenSize =
+        DetailScreenSize.from(configuration.screenWidthDp.dp, configuration.screenHeightDp.dp)
     FarmemeScaffold(
         modifier = modifier,
         topBar = {
@@ -114,7 +114,7 @@ internal fun DetailScreen(
                     .clip(FarmemeRadius.Radius20.shape)
                     .background(FarmemeTheme.backgroundColor.white),
             ) {
-                if (screenHeightPx < 640.dp) {
+                if (currentDetailScreenSize == DetailScreenSize.SMALL) {
                     Box(
                         modifier = Modifier.padding(10.dp),
                         contentAlignment = Alignment.BottomCenter
@@ -126,6 +126,7 @@ internal fun DetailScreen(
                             onClickFunnyButton = onClickFunnyButton,
                             onReactionButtonPositioned = onReactionButtonPosition,
                             onHashTagsClick = onHashTagsClick,
+                            currentDetailScreenSize = currentDetailScreenSize
                         )
                     }
                 } else {
@@ -138,7 +139,8 @@ internal fun DetailScreen(
                             saveBitmap = saveBitmap,
                             onClickFunnyButton = onClickFunnyButton,
                             onReactionButtonPositioned = onReactionButtonPosition,
-                            onHashTagsClick = onHashTagsClick
+                            onHashTagsClick = onHashTagsClick,
+                            currentDetailScreenSize = currentDetailScreenSize
                         )
                     }
                 }

--- a/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/DetailScreen.kt
@@ -23,16 +23,15 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.CachePolicy
 import coil.request.ImageRequest
-import kotlinx.collections.immutable.persistentListOf
 import team.ppac.designsystem.FarmemeTheme
 import team.ppac.designsystem.component.scaffold.FarmemeScaffold
 import team.ppac.designsystem.component.toolbar.FarmemeBackToolBar
 import team.ppac.designsystem.foundation.FarmemeRadius
 import team.ppac.detail.component.DetailBottomBar
 import team.ppac.detail.component.DetailContent
-import team.ppac.detail.model.DetailMemeUiModel
 import team.ppac.detail.mvi.DetailIntent
 import team.ppac.detail.mvi.DetailUiState
+import team.ppac.detail.mvi.DetailUiState.Companion.PREVIEW_STATE
 import team.ppac.detail.util.DetailScreenSize
 
 @Composable
@@ -153,20 +152,7 @@ internal fun DetailScreen(
 @Composable
 fun PreviewDetailScreen() {
     DetailScreen(
-        uiState = DetailUiState(
-            memeId = "",
-            detailMemeUiModel = DetailMemeUiModel(
-                imageUrl = "",
-                name = "나는 공부를 찢어",
-                hashTags = persistentListOf("공부", "학생", "시험기간", "힘듦", "피곤"),
-                sourceDescription = "출처에 대한 내용이 들어갑니다.",
-                isSavedMeme = false,
-                reactionCount = 0,
-                isReaction = false,
-            ),
-            isError = false,
-            isLoading = false,
-        ),
+        uiState = PREVIEW_STATE,
         onClickFunnyButton = {},
         onReactionButtonPosition = { _ -> },
         onClickBackButton = {},

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -65,51 +64,36 @@ internal fun DetailContent(
     onReactionButtonPositioned: (Offset) -> Unit,
     onHashTagsClick: () -> Unit,
 ) {
-    Box(
-        modifier = modifier
-            .border(
-                width = 2.dp,
-                color = FarmemeTheme.borderColor.primary,
-                shape = FarmemeRadius.Radius20.shape,
-            )
-            .clip(FarmemeRadius.Radius20.shape)
-            .background(FarmemeTheme.backgroundColor.white),
+    DetailImage(
+        imageUrl = uiModel.imageUrl,
+        isLoading = isLoading,
+        saveBitmap = saveBitmap,
+    )
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 10.dp)
+            .padding(top = 20.dp, bottom = 10.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Column(
-            modifier = Modifier.padding(10.dp),
-        ) {
-            DetailImage(
-                imageUrl = uiModel.imageUrl,
+        DetailHashTags(
+            name = uiModel.name,
+            sourceDescription = uiModel.sourceDescription,
+            hashTags = uiModel.hashTags,
+            isLoading = isLoading,
+            onHashTagsClick = onHashTagsClick
+        )
+        DetailFunnyButton(
+            modifier = Modifier.mapTextSkeletonModifierIfNeed(
                 isLoading = isLoading,
-                saveBitmap = saveBitmap,
-            )
-            Column(
-                modifier = Modifier
-                    .padding(horizontal = 10.dp)
-                    .padding(top = 20.dp, bottom = 10.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                DetailHashTags(
-                    name = uiModel.name,
-                    sourceDescription = uiModel.sourceDescription,
-                    hashTags = uiModel.hashTags,
-                    isLoading = isLoading,
-                    onHashTagsClick = onHashTagsClick
-                )
-                DetailFunnyButton(
-                    modifier = Modifier.mapTextSkeletonModifierIfNeed(
-                        isLoading = isLoading,
-                        height = 46.dp,
-                        shape = FarmemeRadius.Radius10.shape,
-                    ),
-                    reactionCount = uiModel.reactionCount,
-                    isReaction = uiModel.isReaction,
-                    isLoading = isLoading,
-                    onClickFunnyButton = onClickFunnyButton,
-                    onReactionButtonPositioned = onReactionButtonPositioned,
-                )
-            }
-        }
+                height = 46.dp,
+                shape = FarmemeRadius.Radius10.shape,
+            ),
+            reactionCount = uiModel.reactionCount,
+            isReaction = uiModel.isReaction,
+            isLoading = isLoading,
+            onClickFunnyButton = onClickFunnyButton,
+            onReactionButtonPositioned = onReactionButtonPositioned
+        )
     }
 }
 

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -194,6 +194,7 @@ internal fun DetailHashTags(
     onHashTagsClick: () -> Unit,
     currentDetailScreenSize: DetailScreenSize
 ) {
+    val textColor =  if (currentDetailScreenSize == DetailScreenSize.SMALL) FarmemeTheme.textColor.inverse else FarmemeTheme.textColor.primary
     Text(
         modifier = Modifier.mapTextSkeletonModifierIfNeed(
             isLoading = isLoading,
@@ -201,7 +202,7 @@ internal fun DetailHashTags(
             shape = FarmemeRadius.Radius4.shape,
         ),
         text = name.truncateDisplayedString(16),
-        color = if (currentDetailScreenSize == DetailScreenSize.SMALL) FarmemeTheme.textColor.inverse else FarmemeTheme.textColor.primary,
+        color = textColor,
         style = FarmemeTheme.typography.heading.large.semibold,
         overflow = TextOverflow.Ellipsis
     )
@@ -336,7 +337,7 @@ private fun DetailFunnyButton(
 
 @Composable
 @Preview(showBackground = true)
-fun PreviewDetailContent() {
+private fun PreviewDetailContent() {
     DetailContent(
         modifier = Modifier,
         uiModel = DetailUiState.PREVIEW_STATE.detailMemeUiModel,

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -23,6 +23,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -53,6 +56,8 @@ import team.ppac.designsystem.util.extension.noRippleClickable
 import team.ppac.designsystem.util.extension.rippleClickable
 import team.ppac.detail.model.DetailMemeUiModel
 import team.ppac.detail.mvi.DetailUiState
+import team.ppac.detail.util.DetailScreenSize
+import team.ppac.detail.util.toImageSize
 
 @Composable
 internal fun DetailContent(
@@ -63,12 +68,31 @@ internal fun DetailContent(
     onClickFunnyButton: () -> Unit,
     onReactionButtonPositioned: (Offset) -> Unit,
     onHashTagsClick: () -> Unit,
+    currentDetailScreenSize: DetailScreenSize
 ) {
-    DetailImage(
-        imageUrl = uiModel.imageUrl,
-        isLoading = isLoading,
-        saveBitmap = saveBitmap,
-    )
+    Box {
+        DetailImage(
+            imageUrl = uiModel.imageUrl,
+            isLoading = isLoading,
+            saveBitmap = saveBitmap,
+            currentDetailScreenSize = currentDetailScreenSize
+        )
+        if (currentDetailScreenSize == DetailScreenSize.SMALL) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .graphicsLayer(alpha = 0.80f)
+                    .clip(FarmemeRadius.Radius10.shape)
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(Color.Transparent, FarmemeTheme.iconColor.secondary),
+                            startY = 320f,
+                            endY = 1000f
+                        )
+                    )
+            )
+        }
+    }
     Column(
         modifier = Modifier
             .padding(horizontal = 10.dp)
@@ -80,7 +104,8 @@ internal fun DetailContent(
             sourceDescription = uiModel.sourceDescription,
             hashTags = uiModel.hashTags,
             isLoading = isLoading,
-            onHashTagsClick = onHashTagsClick
+            onHashTagsClick = onHashTagsClick,
+            currentDetailScreenSize = currentDetailScreenSize,
         )
         DetailFunnyButton(
             modifier = Modifier.mapTextSkeletonModifierIfNeed(
@@ -92,7 +117,8 @@ internal fun DetailContent(
             isReaction = uiModel.isReaction,
             isLoading = isLoading,
             onClickFunnyButton = onClickFunnyButton,
-            onReactionButtonPositioned = onReactionButtonPositioned
+            onReactionButtonPositioned = onReactionButtonPositioned,
+            currentDetailScreenSize = currentDetailScreenSize,
         )
     }
 }
@@ -128,7 +154,9 @@ private fun DetailImage(
     imageUrl: String,
     isLoading: Boolean,
     saveBitmap: (Bitmap) -> Unit,
+    currentDetailScreenSize: DetailScreenSize,
 ) {
+    val (widthDp, heightDp) = currentDetailScreenSize.toImageSize()
     Box(
         modifier = Modifier.clip(FarmemeRadius.Radius10.shape)
     ) {
@@ -144,12 +172,12 @@ private fun DetailImage(
             contentScale = ContentScale.Fit,
             modifier = Modifier
                 .background(FarmemeTheme.backgroundColor.black)
-                .width(330.dp)
-                .height(352.dp)
+                .width(widthDp)
+                .height(heightDp)
                 .mapImageSkeletonModifierIfNeed(
                     isLoading = isLoading,
-                    width = 330.dp,
-                    height = 352.dp
+                    width = widthDp,
+                    height = heightDp,
                 ),
             onSuccess = { saveBitmap(it.result.drawable.toBitmap()) }
         )
@@ -164,6 +192,7 @@ internal fun DetailHashTags(
     hashTags: ImmutableList<String>,
     isLoading: Boolean,
     onHashTagsClick: () -> Unit,
+    currentDetailScreenSize: DetailScreenSize
 ) {
     Text(
         modifier = Modifier.mapTextSkeletonModifierIfNeed(
@@ -172,7 +201,7 @@ internal fun DetailHashTags(
             shape = FarmemeRadius.Radius4.shape,
         ),
         text = name.truncateDisplayedString(16),
-        color = FarmemeTheme.textColor.primary,
+        color = if (currentDetailScreenSize == DetailScreenSize.SMALL) FarmemeTheme.textColor.inverse else FarmemeTheme.textColor.primary,
         style = FarmemeTheme.typography.heading.large.semibold,
         overflow = TextOverflow.Ellipsis
     )
@@ -184,7 +213,8 @@ internal fun DetailHashTags(
             shape = FarmemeRadius.Radius4.shape,
         ),
         hashTags = hashTags.truncateDisplayedList(6),
-        onHashTagsClick = onHashTagsClick
+        onHashTagsClick = onHashTagsClick,
+        currentDetailScreenSize = currentDetailScreenSize
     )
     if (sourceDescription.isNotEmpty()) {
         Spacer(modifier = Modifier.height(11.dp))
@@ -209,23 +239,25 @@ internal fun DetailTags(
     modifier: Modifier,
     hashTags: List<String>,
     onHashTagsClick: () -> Unit,
+    currentDetailScreenSize: DetailScreenSize,
 ) {
     Text(
         modifier = modifier.noRippleClickable(onClick = onHashTagsClick),
         text = hashTags.joinToString(" ") { "#$it" },
-        color = FarmemeTheme.textColor.tertiary,
+        color = if (currentDetailScreenSize == DetailScreenSize.SMALL) FarmemeTheme.textColor.disabled else FarmemeTheme.textColor.tertiary,
         style = FarmemeTheme.typography.body.large.medium,
     )
 }
 
 @Composable
-fun DetailFunnyButton(
+private fun DetailFunnyButton(
     modifier: Modifier = Modifier,
     reactionCount: Int,
     isReaction: Boolean,
     isLoading: Boolean,
     onClickFunnyButton: () -> Unit,
     onReactionButtonPositioned: (Offset) -> Unit,
+    currentDetailScreenSize: DetailScreenSize,
 ) {
     val lottieComposition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.lol_move_effect))
     val coroutineScope = rememberCoroutineScope()
@@ -235,7 +267,7 @@ fun DetailFunnyButton(
             .fillMaxWidth()
             .height(46.dp)
             .clip(FarmemeRadius.Radius10.shape)
-            .background(color = FarmemeTheme.skeletonColor.primary)
+            .background(color = if (currentDetailScreenSize == DetailScreenSize.SMALL) FarmemeTheme.backgroundColor.white else FarmemeTheme.skeletonColor.primary)
             .rippleClickable(
                 rippleColor = FarmemeTheme.skeletonColor.secondary,
                 onClick = {
@@ -312,6 +344,7 @@ fun PreviewDetailContent() {
         onClickFunnyButton = {},
         onReactionButtonPositioned = { _ -> },
         isLoading = false,
-        onHashTagsClick = {}
+        onHashTagsClick = {},
+        currentDetailScreenSize = DetailScreenSize.MEDIUM
     )
 }

--- a/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/component/DetailContent.kt
@@ -339,7 +339,7 @@ private fun DetailFunnyButton(
 fun PreviewDetailContent() {
     DetailContent(
         modifier = Modifier,
-        uiModel = DetailUiState.INITIAL_STATE.detailMemeUiModel,
+        uiModel = DetailUiState.PREVIEW_STATE.detailMemeUiModel,
         saveBitmap = {},
         onClickFunnyButton = {},
         onReactionButtonPositioned = { _ -> },

--- a/feature/detail/src/main/java/team/ppac/detail/mvi/DetailUiState.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/mvi/DetailUiState.kt
@@ -26,6 +26,21 @@ data class DetailUiState(
             isError = false,
             isLoading = false,
         )
+
+        val PREVIEW_STATE = DetailUiState(
+            memeId = "",
+            detailMemeUiModel = DetailMemeUiModel(
+                imageUrl = "",
+                name = "나는 공부를 찢어",
+                hashTags = persistentListOf("공부", "학생", "시험기간", "힘듦", "피곤"),
+                sourceDescription = "출처에 대한 내용이 들어갑니다.",
+                isSavedMeme = false,
+                reactionCount = 0,
+                isReaction = false,
+            ),
+            isError = false,
+            isLoading = false,
+        )
     }
 }
 

--- a/feature/detail/src/main/java/team/ppac/detail/util/DetailScreenSize.kt
+++ b/feature/detail/src/main/java/team/ppac/detail/util/DetailScreenSize.kt
@@ -1,0 +1,26 @@
+package team.ppac.detail.util
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+internal enum class DetailScreenSize(val width: Dp, val height: Dp) {
+    SMALL(360.dp, 640.dp),
+    MEDIUM(360.dp, 800.dp),
+    LARGE(430.dp, 932.dp);
+
+    companion object {
+        fun from(width: Dp, height: Dp): DetailScreenSize {
+            return entries.find { screenSize ->
+                height <= screenSize.height
+            } ?: LARGE
+        }
+    }
+}
+
+internal fun DetailScreenSize.toImageSize(): Pair<Dp, Dp> {
+    return when (this) {
+        DetailScreenSize.SMALL -> Pair(300.dp, 320.dp)
+        DetailScreenSize.MEDIUM -> Pair(330.dp, 352.dp)
+        DetailScreenSize.LARGE -> Pair(366.dp, 390.dp)
+    }
+}


### PR DESCRIPTION
### Issue
- close #101

### 작업 내역 (Required)
- detail 스크린의 height 사이즈 별로 small, medium, large로 구분
- small일때 texts 영역 image와 겹쳐서 보이도록 구조 벼경
- small일때 image에 그라데이션 추가
- small일때 button, text 컬러 변경
- small, medium, large일때 image 사이즈 변경

### Review Point (Required)
- 정의해준 기준에서 W가 360이하일때가 small로 판단하는데 디테일스크린에서 모든 component가 배치가 세로로 되어있고 정렬 기준이 가로센터로 되어있어서  가로사이즈 변경에 의해 잘리는 부분이 없어서 W 사이즈는 small로 구분하는데 사용안했습니다! 


![image](https://github.com/user-attachments/assets/5cadf960-9c18-4ca3-b793-3aa1a9d99abd)


### Screenshot
test용으로 W,H dp사이즈 출력했고 commit에서는 지웠어염
https://github.com/user-attachments/assets/672f9221-84de-4003-b031-513a9a1b35fd


